### PR TITLE
Updated remote templates repo manifest and format

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@
 
 ## Why prich?
 - **Any Prompt, Any Domain**: Build prompts for coding (e.g., code review), data analysis (e.g., CSV summaries), content creation, or customer support, with preprocessing to prepare data (e.g., parse CSVs, clean text).
-- **Team Collaboration**: Share template packages via git repos, file transfers, or cloud storage (e.g., Google Drive, Dropbox), ensuring consistent LLM outputs across teams.
+- **Team Collaboration**: Share template packages via git repos - just add `.prich` folder with your shared templates, file transfers, or cloud storage (e.g., Google Drive, Dropbox), ensuring consistent LLM outputs across teams.
 - **Simple and Hackable**: Intuitive CLI and YAML configs make it easy to craft dynamic prompts, with support for Python, shell, or any scripting language.
-- **Portable**: Isolated virtual environments (default and custom venvs) ensure dependency safety and portability.
+- **Portable**: Isolated virtual environments (default and custom venvs) ensure dependency safety and portability; or use standard commands like git, cat, etc.
+
+#### [See prich templates repository for examples](https://github.com/oleks-dev/prich-templates/blob/main/templates/index.md)
 
 ## Key Features
 - **Modular Prompts**: Define prompts with Jinja2 templates and per-template YAML configs.

--- a/prich/models/template_repo_manifest.py
+++ b/prich/models/template_repo_manifest.py
@@ -1,0 +1,25 @@
+from pydantic import BaseModel
+from typing import List, Literal
+
+class TemplateRepoItem(BaseModel):
+    id: str
+    name: str
+    version: str
+    schema_version: str
+    archive: str
+    archive_checksum: str
+    author: str
+    description: str
+    files: list
+    folder_checksum: str
+    tags: list[str]
+
+
+class TemplatesRepoManifest(BaseModel):
+    archives_path: str
+    name: str
+    description: str
+    repository: str
+    schema_version: Literal["1.0"]
+    templates: List[TemplateRepoItem]
+    templates_path: str


### PR DESCRIPTION
### Summary of Changes

The diff introduces several improvements to enhance **team collaboration**, **template management**, and **portability** in the `prich` tool. Key updates include:

1. **README.md Enhancements**:
   - Added a **new section** linking to the [prich templates repository](https://github.com/oleks-dev/prich-templates) for examples.
   - Clarified how to **share templates via Git** by adding a `.prich` folder with templates.
   - Expanded the **"Portable"** feature to mention **standard commands** like `git` and `cat` for flexibility.
   - Improved wording for **team collaboration** to emphasize consistency across teams.

2. **CLI Code Refactoring**:
   - Updated the `list_github_templates` function to fetch a **manifest.json** instead of an `index.json`, aligning with a new structured data format.
   - Introduced **Pydantic models** (`TemplateRepoItem` and `TemplatesRepoManifest`) to represent template metadata, ensuring type safety and validation.
   - Added **checksum columns** (Archive/Folder) to the CLI output for integrity verification.
   - Included a **new install command instruction** (`prich install -r <template_id>`) to guide users on installing templates.

3. **New File**:
   - Created `template_repo_manifest.py` to define the data models for the template repository manifest, centralizing metadata structure.