### PR TITLE
added quick start guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@
 - **Secure venv Management**: Default (`.prich/venv/`) and custom Python venvs (e.g., `.prich/templates/code_review/scripts/venv`) isolate dependencies.
 - **Simple CLI**: Commands like `prich run` and `prich install` streamline workflows.
 
+## Quick Start
+1. Install `prich` tool (see `Installation`)
+2. Initialize config (use global for the start): `prich init --global`
+3. Create simple example template (`prich create <template_id>`): `prich create my-template`
+4. Run template (`prich run <template_id>`): `prich run my-template`
+> Note: By default prich will set up and use echo provider which just outputs the rendered template  
+> To use it with LLM see `Configure .prich/config.yaml` and follow it to add your LLM provider  
+
+Optionally you can also run for the start:  
+* Run template with help flag (`prich run <template_id> --help`): `prich run my-template --help`
+* See installed templates: `prich list`
+* See templates available for installation from the remote repo: `prich list --remote`
+
 ## Execution Example
 
 ```commandline


### PR DESCRIPTION
This commit enhances the `prich` by adding a **Quick Start guide** to the `README.md` and improving the `create_template` functionality in `templates.py`. Key changes include:  
1. **README.md**:  
   - Added a "Quick Start" section with step-by-step instructions for initializing, creating, and running templates.  
   - Included notes about the default echo provider and LLM configuration.  
   - Highlighted optional commands like `prich run --help`, `prich list`, and `prich list --remote`.  

2. **templates.py**:  
   - Introduced an `--edit` flag to open the newly created template YAML file in the default editor.  
   - Improved variable definitions (e.g., `cli_option`, `default`, `required`).  
   - Enhanced YAML output formatting with `indent=2` and `sort_keys=False` for readability.  
   - Fixed grammar in the error message for duplicate templates.  