### PR TITLE
new tests for loaders and other test updates

### DIFF
--- a/prich/core/loaders.py
+++ b/prich/core/loaders.py
@@ -2,7 +2,7 @@ import click
 from pathlib import Path
 from typing import Dict, Optional, Tuple, List
 from prich.core.file_scope import classify_path
-from prich.core.state import _loaded_templates, _loaded_config
+from prich.core.state import _loaded_templates, _loaded_config, _loaded_config_paths
 from prich.core.utils import console_print, shorten_home_path, get_prich_dir
 from prich.models.utils import recursive_update
 from prich.models.config import ConfigModel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 [project.optional-dependencies]
 openai = ["openai>=1.0.0"]
 mlx = ["mlx_lm>=0.24.1"]
-dev = ["pytest", "coverage", "pytest-cov", "twine", "build"]
+dev = ["pytest", "coverage", "pytest-cov", "twine", "build", "faker"]
 
 [project.urls]
 Homepage = "https://github.com/oleks-dev/prich"

--- a/tests/fixtures/config.py
+++ b/tests/fixtures/config.py
@@ -1,0 +1,84 @@
+import pytest
+import yaml
+from pydantic import TypeAdapter
+from prich.models.config import ConfigModel
+
+
+@pytest.fixture
+def basic_config():
+    adapter = TypeAdapter(ConfigModel)
+    config = """
+schema_version: "1.0"
+providers:
+  show_prompt:
+    mode: flat
+    provider_type: echo
+provider_modes:
+  - name: plain
+    prompt: '{{ prompt }}'
+  - name: flat
+    prompt: |-
+      {% if system %}### System:
+      {{ system }}
+
+      {% endif %}### User:
+      {{ user }}
+
+      ### Assistant:
+settings: 
+    default_provider: "show_prompt"
+    editor: "vi"
+"""
+    config = adapter.validate_python(yaml.safe_load(config))
+    return config
+
+@pytest.fixture
+def basic_config_with_prompts():
+    adapter = TypeAdapter(ConfigModel)
+    config = """
+schema_version: "1.0"
+providers:
+  show_prompt:
+    mode: flat
+    provider_type: echo
+provider_modes:
+  - name: plain
+    prompt: '{{ prompt }}'
+  - name: flat
+    prompt: |-
+      {% if system %}### System:
+      {{ system }}
+
+      {% endif %}### User:
+      {{ user }}
+
+      ### Assistant:
+  - name: mistral-instruct
+    prompt: |-
+      <s>[INST]
+      {% if system %}{{ system }}
+
+      {% endif %}{{ user }}
+      [/INST]
+  - name: llama2-chat
+    prompt: |-
+      <s>[INST]
+      {% if system %}{{ system }}
+
+      {% endif %}{{ user }}
+      [/INST]
+  - name: anthropic
+    prompt: |-
+      Human: {% if system %}{{ system }}
+
+      {% endif %}{{ user }}
+
+      Assistant:
+  - name: chatml
+    prompt: '[{% if system %}{"role": "system", "content": "{{ system }}"},{% endif %}{"role": "user", "content": "{{ user }}"}]'
+settings: 
+    default_provider: "show_prompt"
+    editor: "vi"
+"""
+    config = adapter.validate_python(yaml.safe_load(config))
+    return config

--- a/tests/fixtures/templates.py
+++ b/tests/fixtures/templates.py
@@ -1,0 +1,49 @@
+import pytest
+from pathlib import Path
+from prich.models.template import TemplateModel, VariableDefinition, PythonStep, LLMStep, PromptFields
+from tests.generate.templates import generate_template, templates
+
+
+@pytest.fixture
+def template_with_python_and_venv(tmp_path, isolated_venv: bool = False) -> TemplateModel:
+    return generate_template(tmp_path, isolated_venv=isolated_venv)
+
+@pytest.fixture()
+def templates_fixture(request):
+    params = request.param
+    def call(**kw):
+        return templates(**{**params, **kw})
+    return call
+
+@pytest.fixture
+def template(tmp_path):
+    tpl = TemplateModel(
+        schema_version="1.0",
+        version="1.0",
+        id="tpl",
+        name="tpl",
+        description="Test template",
+        tags=["test"],
+        variables=[
+            VariableDefinition(
+                name="name",
+                type="str",
+                default="Assistant",
+                required=False
+            )
+        ],
+        steps=[
+            LLMStep(
+                name="llm step",
+                type="llm",
+                prompt=PromptFields(
+                    system="Hi {{ name }}",
+                    user="Analyse `{{ test_output }}`?"
+                )
+            )
+        ],
+        source="local",
+        folder=str(tmp_path),
+        file="",
+    )
+    return tpl

--- a/tests/generate/templates.py
+++ b/tests/generate/templates.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+
+from faker import Faker
+from prich.models.file_scope import FileScope
+
+from prich.models.template import TemplateModel, VariableDefinition, PythonStep, LLMStep, PromptFields
+
+faker = Faker()
+
+def generate_template(prich_path: Path = ".", template_id: str=None, isolated_venv: bool = False, global_location: bool = False):
+    tpl_name = faker.company()
+    tpl_description = faker.text(max_nb_chars=100)
+    if not template_id:
+        template_id = faker.company()
+    tpl_id = template_id.lower().replace(", ", "-").replace(". ", "-").replace(" ", "-")
+
+    tpl = TemplateModel(
+        schema_version="1.0",
+        version="1.0",
+        id=tpl_id,
+        author=faker.name(),
+        name=tpl_name,
+        description=tpl_description,
+        tags=[faker.word(ext_word_list=tpl_description.replace(",", "").replace(".", "").split(" ")).lower()],
+        variables=[
+            VariableDefinition(
+                name="name",
+                type="str",
+                default="Assistant",
+                required=False
+            )
+        ],
+        venv="shared" if not isolated_venv else "isolated",
+        steps=[
+            PythonStep(
+                name="Preprocess",
+                call="test.py",
+                type="python",
+                args=[],
+                output_variable="test_output"
+            ),
+            LLMStep(
+                name="LLM Step",
+                type="llm",
+                prompt=PromptFields(
+                    system=f"You are {{ name }}, {faker.text(80)}",
+                    user=f"Analyse `{{ test_output }}`, {faker.text(40)}"
+                )
+            )
+        ],
+        source=FileScope.LOCAL if not global_location else FileScope.GLOBAL,
+        folder=str(prich_path / "templates"),
+        file=str(prich_path / "templates" / f"{tpl_id}.yaml"),
+    )
+    return tpl
+
+def templates(count: int = 1, isolated_venv: bool = False, global_location: bool = False, tag_first_n: int = None):
+    templates_list = []
+    index = 0
+    tag_group_index = 1
+    tag_name = f"{faker.word()}{tag_group_index}".lower()
+    for i in range(0, count):
+        index += 1
+        if tag_first_n and index > tag_first_n:
+            tag_group_index = +1
+            tag_name = f"{faker.word()}{tag_group_index}".lower()
+        tpl = generate_template(prich_path=Path("."), isolated_venv=isolated_venv, global_location=global_location)
+        tpl.id = f"{tpl.id}{index}"
+        if tag_first_n:
+            tpl.tags.append(tag_name)
+        templates_list.append(tpl)
+    return templates_list

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -1,0 +1,115 @@
+import os
+from pathlib import Path
+
+import click
+import pytest
+
+from tests.fixtures.config import basic_config
+from tests.generate.templates import templates
+from prich.core.state import _loaded_templates, _loaded_config_paths
+from prich.core.loaders import get_loaded_templates, get_loaded_template, get_loaded_config
+
+get_loaded_templates_CASES = [
+    {"id": "no_templates", "count": 0, "isolated_venv": False, "global_location": False, "expected_count": 0},
+    {"id": "5_templates", "count": 5, "isolated_venv": False, "global_location": False, "expected_count": 5},
+    {"id": "50_templates", "count": 50, "isolated_venv": False, "global_location": False, "expected_count": 50},
+    {"id": "3_templates", "count": 3, "isolated_venv": True, "global_location": True, "expected_count": 3},
+    {"id": "3_templates", "count": 3, "isolated_venv": True, "global_location": False, "expected_count": 3},
+    {"id": "20_templates_5_with_tag", "count": 20, "isolated_venv": True, "global_location": True, "expected_count": 5, "tag_first_n": 5},
+    {"id": "20_templates_10_with_tag", "count": 20, "isolated_venv": True, "global_location": False, "expected_count": 10, "tag_first_n": 10},
+]
+@pytest.mark.parametrize("case", get_loaded_templates_CASES, ids=[c["id"] for c in get_loaded_templates_CASES])
+def test_get_loaded_templates(monkeypatch, basic_config, case):
+    _loaded_templates.clear()
+    tpl = templates(count=case.get("count"), isolated_venv=case.get("isolated_venv"), global_location=case.get("global_location"), tag_first_n=case.get("tag_first_n", None))
+
+    monkeypatch.setattr("prich.core.loaders.load_templates", lambda: tpl)
+    if case.get("tag_first_n"):
+        tags = [tpl[0].tags[1]]
+    else:
+        tags = None
+    print(tags)
+    actual = get_loaded_templates(tags)
+    assert len(actual) == case.get("expected_count")
+
+
+get_loaded_template_CASES = [
+    {"id": "local_template", "count": 1, "global_location": False},
+    {"id": "global_template", "count": 1, "global_location": True},
+]
+@pytest.mark.parametrize("case", get_loaded_template_CASES, ids=[c["id"] for c in get_loaded_template_CASES])
+def test_get_loaded_template(monkeypatch, case):
+    _loaded_templates.clear()
+    tpl = templates(count=case.get("count"), isolated_venv=case.get("isolated_venv"), global_location=case.get("global_location"))
+
+    monkeypatch.setattr("prich.core.loaders.load_templates", lambda: tpl)
+
+    loaded_template = get_loaded_template(tpl[0].id)
+    assert loaded_template
+
+
+
+get_loaded_config_CASES = [
+    {"id": "local_config", "local_only": True, "expected_providers": ["show_prompt", "local_show_prompt"], "expected_loaded_files": ["local_config.yaml"]},
+    {"id": "global_config", "global_only": True, "expected_providers": ["show_prompt", "global_show_prompt"], "expected_loaded_files": ["global_config.yaml"]},
+    {"id": "merged_config", "expected_providers": ["show_prompt", "global_show_prompt", "local_show_prompt"], "expected_loaded_files": ["global_config.yaml", "local_config.yaml"]},
+]
+@pytest.mark.parametrize("case", get_loaded_config_CASES, ids=[c["id"] for c in get_loaded_config_CASES])
+def test_get_loaded_config(monkeypatch, case, basic_config):
+    from prich.core.state import _loaded_config, _loaded_config_paths
+    if _loaded_config:
+        _loaded_config.clear()
+    if _loaded_config_paths:
+        _loaded_config_paths.clear()
+    local_config = basic_config.copy(deep=True)
+    local_providers = local_config.providers
+    local_config.providers.update({'local_show_prompt': list(local_providers.items())[0][1]})
+    global_config = basic_config.copy(deep=True)
+    global_config.providers.update({'global_show_prompt': list(local_providers.items())[0][1]})
+
+    monkeypatch.setattr("prich.core.loaders._loaded_config", _loaded_config)
+    monkeypatch.setattr("prich.core.loaders._loaded_config_paths", _loaded_config_paths)
+    monkeypatch.setattr("prich.core.loaders.load_global_config", lambda: (global_config, "global_config.yaml"))
+    monkeypatch.setattr("prich.core.loaders.load_local_config", lambda: (local_config, "local_config.yaml"))
+    monkeypatch.setattr("prich.core.utils.should_use_global_only", lambda: case.get("global_only", False))
+    monkeypatch.setattr("prich.core.utils.should_use_local_only", lambda: case.get("local_only", False))
+
+    loaded_config, loaded_files = get_loaded_config()
+
+    assert loaded_config, "Failed to load config"
+    assert list(loaded_config.providers.keys()) == case.get("expected_providers")
+    assert list(loaded_files) == case.get("expected_loaded_files")
+
+
+def test_load_yaml_no_file():
+    from prich.core.loaders import _load_yaml
+    test_yaml = Path("test_not_present.yaml")
+    actual = _load_yaml(test_yaml)
+    assert actual == {}
+
+def test_load_config_model_no_file():
+    from prich.core.loaders import load_config_model
+    test_yaml = Path("test_not_present.yaml")
+    actual = load_config_model(test_yaml)
+    assert actual == (None, test_yaml)
+
+def test_load_config_model_wrong_schema(monkeypatch):
+    from prich.core.loaders import load_config_model
+    monkeypatch.setattr("prich.core.loaders._load_yaml", lambda x: ({"schema_version": "0.0"}))
+    test_yaml = Path("test_not_present.yaml")
+    with pytest.raises(click.ClickException):
+        actual = load_config_model(test_yaml)
+        assert actual == (None, test_yaml)
+
+def test_find_template_files(tmp_path, monkeypatch):
+    from prich.core.loaders import find_template_files
+    prich_dir = tmp_path / ".prich"
+    templates_dir = prich_dir / "templates"
+    template_dir = templates_dir / "test-template"
+    os.makedirs(template_dir, exist_ok=True)
+    test_yaml = template_dir / "test-template.yaml"
+    with open(test_yaml, 'w') as file:
+        file.write("")
+    actual = find_template_files(prich_dir.parent)
+    test_yaml.unlink()
+    assert len(actual), 1

--- a/tests/test_template_install.py
+++ b/tests/test_template_install.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 from prich.cli.templates import template_install
-from prich.core.loaders import load_config_model, _load_template_model
+from prich.core.loaders import load_config_model, load_template_model
 from prich.core.engine import render_prompt
 from prich.models.template import PromptFields
 
@@ -128,7 +128,7 @@ def test_render_template_prompt_basic():
 
     fields = PromptFields(system="Hello {{ name }}", user="Your input is {{ value }}")
     variables = {"name": "Test", "value": "XYZ"}
-    rendered = render_prompt(config_model, fields, variables, template_dir=".", mode="flat")
+    rendered = render_prompt(config_model, fields, variables, mode="flat")
     assert "Hello Test" in rendered
     assert "Your input is XYZ" in rendered
 
@@ -137,5 +137,5 @@ def test_invalid_template_validation():
         file_path = Path(tmpdir) / "invalid.yaml"
         file_path.write_text(INVALID_TEMPLATE_YAML)
         with pytest.raises(Exception) as exc:
-            _load_template_model(file_path)
+            load_template_model(file_path)
         assert "Field required" in str(exc.value)


### PR DESCRIPTION
Test Updates:
- `pyproject.toml`:  Dev dependency `faker` was added.
- Fixtures: New `tests/fixtures/__init__.py`, `config.py` (basic & prompt‑rich configs), `templates.py` (simple template fixture).
- Template generator: `tests/generate/templates.py` - helper that builds realistic `TemplateModel` objects with random data via `faker`.
- New tests: `tests/test_loaders.py` covers template and config loading, YAML loading, and file discovery.
- Existing tests updated: 
  - `tests/test_engine.py` - removed in‑test config fixture; now imports `basic_config_with_prompts`.  The `render_prompt` call no longer passes `template_dir`; `render_template` signature now takes only the string and variables.
  - `tests/test_run_template.py` - uses the fixture `basic_config`; changes the way templates are registered (`_loaded_templates[template.id]`).
  - `tests/test_template_install.py` - imports `load_template_model` instead of the private `_load_template_model`.
- **Utility changes**:
  - `render_prompt` and `render_template` signature changes in the core engine; the tests reflect this. 
  - `load_config_model` now raises `click.ClickException` on an unexpected `schema_version`.
  - `find_template_files` is exercised; test uses `assert len(actual), 1` (truthiness).
  - Added helper `templates()` to create lists of templates with optional tagging and isolation.