### PR TITLE
more tests for init, listing, loaders, models, and validate

### DIFF
--- a/tests/generate/templates.py
+++ b/tests/generate/templates.py
@@ -70,3 +70,13 @@ def templates(count: int = 1, isolated_venv: bool = False, global_location: bool
             tpl.tags.append(tag_name)
         templates_list.append(tpl)
     return templates_list
+
+def templates_list_to_dict(templates_list: list):
+    tpl_dict = {}
+    for tpl in templates_list:
+        tpl_dict[tpl.id] = tpl
+    return tpl_dict
+
+def templates_dict(count: int = 1, isolated_venv: bool = False, global_location: bool = False, tag_first_n: int = None):
+    templates_list = templates(count=count, isolated_venv=isolated_venv, global_location=global_location, tag_first_n=tag_first_n)
+    return templates_list_to_dict(templates_list)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+import pytest
+from click.testing import CliRunner
+
+get_init_cmd_CASES = [
+    {"id": "init_global", "args_1": ["-g"], "init_folder": "global",
+     "expected_output_1": "Initialized prich at "},
+    {"id": "init", "args_1": [], "init_folder": "local",
+     "expected_output_1": "Initialized prich at "},
+    {"id": "double_init_global_exist", "args_1": ["-g"], "args_2": ["-g"], "init_folder": "global",
+     "expected_output_1": "Initialized prich at ", "expected_output_2": "exists. Use --force to overwrite"},
+    {"id": "double_init_local_exist", "args_1": [], "args_2": [], "init_folder": "local",
+     "expected_output_1": "Initialized prich at ", "expected_output_2": "exists. Use --force to overwrite"},
+    {"id": "double_init_global_force", "args_1": ["-g"], "args_2": ["-g", "--force"], "init_folder": "global",
+     "expected_output_1": "Initialized prich at ", "expected_output_2": "Initialized prich at "},
+    {"id": "double_init_local_force", "args_1": [], "args_2": ["--force"], "init_folder": "local",
+     "expected_output_1": "Initialized prich at ", "expected_output_2": "Initialized prich at "},
+]
+@pytest.mark.parametrize("case", get_init_cmd_CASES, ids=[c["id"] for c in get_init_cmd_CASES])
+def test_init_cmd(tmp_path, monkeypatch, case):
+    from prich.cli.init_cmd import init
+
+    global_dir = tmp_path / "home"
+    local_dir = tmp_path / "local"
+    global_dir.mkdir()
+    local_dir.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: global_dir)
+    monkeypatch.setattr(Path, "cwd", lambda: local_dir)
+
+    if case.get("init_folder") == "global":
+        prich_dir = global_dir / ".prich"
+    elif case.get("init_folder") == "local":
+        prich_dir = local_dir / ".prich"
+    else:
+        assert False, "Wrong init_folder param specified"
+
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        result = runner.invoke(init, case.get("args_1"))
+        if case.get("expected_output_1") is not None:
+            assert case.get("expected_output_1") in result.output
+        if case.get("init_folder"):
+            assert (prich_dir / "config.yaml").exists()
+            assert (prich_dir / "venv").exists()
+        if case.get("expected_output_2") is not None:
+            result = runner.invoke(init, case.get("args_2"))
+            assert case.get("expected_output_2") in result.output

--- a/tests/test_listing.py
+++ b/tests/test_listing.py
@@ -1,0 +1,86 @@
+import pytest
+from click.testing import CliRunner
+
+from tests.generate.templates import templates, templates_list_to_dict
+
+get_list_tags_CASES = [
+    {"id": "local", "count": 4, "args": ["-l"],
+     "expected_output": "Available tags (local):"},
+    {"id": "global", "count": 5, "args": ["-g"],
+     "expected_output": "Available tags (global):"},
+    {"id": "tags", "count": 9, "args": [],
+     "expected_output": "Available tags:"},
+    {"id": "no_templates", "count": 0, "args": [],
+     "expected_output": "No templates installed. Use 'prich template install' to add templates.\n"},
+    {"id": "l_g_params", "count": 0, "args": ['-l', '-g'],
+     "expected_output": "Use only one local or global option, use"},
+]
+@pytest.mark.parametrize("case", get_list_tags_CASES, ids=[c["id"] for c in get_list_tags_CASES])
+def test_list_tags(tmp_path, monkeypatch, case):
+    from prich.cli.listing import list_tags
+    from prich.core.state import _loaded_templates
+    _loaded_templates.clear()
+    template_list = templates(count=case.get("count"), isolated_venv=False, global_location=False)
+
+    monkeypatch.setattr("prich.core.loaders.load_templates", lambda: template_list)
+
+    tags = [x.tags[0] for x in template_list]
+    tags_list = []
+    for tag in tags:
+        if tag not in tags_list:
+            tags_list.append(tag)
+    expected_tags_number = len(tags_list)
+
+    template_dict = templates_list_to_dict(template_list)
+    _loaded_templates.update(template_dict)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        result = runner.invoke(list_tags, case.get("args"))
+        if case.get("expected_output") is not None:
+            assert case.get("expected_output") in result.output
+            assert len(result.output.split('\n')) == expected_tags_number + 2
+
+
+get_list_templates_CASES = [
+    {"id": "local_json_only", "count": 4, "args": ["-l", "-j"],
+     "expected_output": "{\n", "check_count": False},
+    {"id": "local", "count": 4, "args": ["-l"],
+     "expected_output": "Available templates:\n"},
+    {"id": "global", "count": 8, "args": ["-g"],
+     "expected_output": "Available templates:\n"},
+    {"id": "remote_and_l_fail", "count": 1, "args": ["--remote", "-l"],
+     "expected_output": "When listing remote templates available for installation the global or local options are not supported", "check_count": False},
+    {"id": "remote_and_g_fail", "count": 1, "args": ["--remote", "-g"],
+     "expected_output": "When listing remote templates available for installation the global or local options are not supported", "check_count": False},
+    {"id": "l_and_g_fail", "count": 1, "args": ["-l", "-g"],
+     "expected_output": "Use only one local or global option, use", "check_count": False},
+    {"id": "no_templates", "count": 0, "args": [],
+     "expected_output": "No templates found. Use", "check_count": False},
+    {"id": "no_templates_with_tag", "count": 0, "args": ["--tag", "test"],
+     "expected_output": "No templates found with specified tags:", "check_count": False},
+    {"id": "remote_list", "count": 0, "args": ["--remote"],
+     "expected_output": "prich Templates", "check_count": False},
+    {"id": "remote_list_tag_no_result", "count": 0, "args": ["--remote", "--tag", "notexisting"],
+     "expected_output": "No templates found by provided tags", "check_count": False},
+    {"id": "remote_list_tag", "count": 0, "args": ["--remote", "--tag", "code"],
+     "expected_output": "prich Templates", "check_count": False},
+    {"id": "remote_list_json", "count": 0, "args": ["--remote", "--json"],
+     "expected_output": "{\n", "check_count": False},
+]
+@pytest.mark.parametrize("case", get_list_templates_CASES, ids=[c["id"] for c in get_list_templates_CASES])
+def test_list_templates(tmp_path, monkeypatch, case):
+    from prich.cli.listing import list_templates
+    from prich.core.state import _loaded_templates
+    _loaded_templates.clear()
+    template_list = templates(count=case.get("count"), isolated_venv=False, global_location=False)
+
+    monkeypatch.setattr("prich.core.loaders.load_templates", lambda: template_list)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        result = runner.invoke(list_templates, case.get("args"))
+        if case.get("expected_output") is not None:
+            assert case.get("expected_output") in result.output
+            if case.get("check_count", True):
+                assert len(result.output.split('- ')) == len(template_list) + 1

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,202 @@
+import os
+from pathlib import Path
+
+import click
+import pydantic
+import pytest
+from prich.models.file_scope import FileScope
+
+from prich.models.template import TemplateModel
+
+from prich.models.template_repo_manifest import TemplatesRepoManifest
+from tests.fixtures.config import basic_config
+
+def test_model_template_repo_manifest():
+    test_repo = {
+      "archives_path": "https://github.com/oleks-dev/prich-templates/tree/main/dist",
+      "templates_path": "https://github.com/oleks-dev/prich-templates/tree/main/templates",
+      "description": "Templates Available for Installation from prich-templates GitHub Repository",
+      "name": "prich Templates",
+      "repository": "https://github.com/oleks-dev/prich-templates",
+      "schema_version": "1.0",
+      "templates": [
+        {
+          "archive": "cli-expert.zip",
+          "archive_checksum": "38c5def03643406f9844e1dde12c2fa69eaa6f570aa1d510f90d682dd5f05a12",
+          "author": "prich",
+          "description": "CLI command usage helper providing real-world examples for shell commands across different operating systems.",
+          "files": [
+            "cli-expert/cli-expert.yaml"
+          ],
+          "folder_checksum": "f9b55f89d3b6ec28aff63665c1e410689a9f3f7f09b7bde0eada49f5be6259e6",
+          "id": "cli-expert",
+          "name": "CLI Expert",
+          "schema_version": "1.0",
+          "tags": [
+            "os",
+            "cli",
+            "shell",
+            "helper"
+          ],
+          "version": "1.0",
+        }
+      ]
+    }
+    actual = TemplatesRepoManifest(**test_repo)
+    assert len(actual.templates) == 1
+
+
+get_model_template_CASES = [
+    {
+      "id": "duplicate_step_name",
+      "data": {
+        "id": "test",
+        "name": "Test",
+        "schema_version": "1.0",
+        "steps": [
+          {"name": "step1",
+           "call": "",
+           "args": [],
+           "type": "python"},
+          {"name": "step1",
+           "call": "",
+           "args": [],
+           "type": "command"},
+        ]
+      },
+      "expected_exception": click.ClickException,
+      "expected_exception_text": "Duplicate test template step name (#2): 'step1'"
+    },
+    {
+      "id": "invalid_step_type",
+      "data": {
+        "id": "test",
+        "name": "Test",
+        "schema_version": "1.0",
+        "steps": [
+          {"name": "step1",
+           "call": "",
+           "args": [],
+           "type": "notsupported"}
+        ]
+      },
+      "expected_exception": pydantic.ValidationError,
+      "expected_exception_text": "Input tag 'notsupported' found using 'type' does not match any of the expected tags"
+    },
+    {
+      "id": "invalid_variable_name",
+      "data": {
+        "id": "test",
+        "name": "Test",
+        "schema_version": "1.0",
+        "steps": [
+        ],
+        "variables": [
+          {"name": "wrong-variable-name"}
+        ]
+      },
+      "expected_exception": click.ClickException,
+      "expected_exception_text": "Invalid variable name 'wrong-variable-name' in test template"
+    },
+]
+@pytest.mark.parametrize("case", get_model_template_CASES, ids=[c["id"] for c in get_model_template_CASES])
+def test_model_template(case):
+  if case.get("expected_exception") is not None:
+    with pytest.raises(case.get("expected_exception")) as e:
+      TemplateModel(**case.get("data"))
+    if case.get("expected_exception_text") is not None:
+      if case.get("expected_exception") == click.ClickException:
+        assert case.get("expected_exception_text") in e.value.message
+      else:
+        assert case.get("expected_exception_text") in str(e.value)
+  else:
+    TemplateModel(**case.get("data"))
+
+
+get_model_template_save_CASES = [
+  {"id": "failed_to_save",
+   "template": TemplateModel(
+      id = "test1",
+      name = "Test1",
+      steps = []),
+   "location": None, "expected_exception": click.ClickException},
+  {"id": "saved_local",
+   "template": TemplateModel(
+      id = "test2",
+      name = "Test2",
+      steps = []),
+   "location": FileScope.LOCAL},
+  {"id": "saved_global",
+   "template": TemplateModel(
+     id="test3",
+     name="Test3",
+     steps=[]),
+   "location": FileScope.GLOBAL},
+  {"id": "saved_local_from_source",
+   "template": TemplateModel(
+     id="test4",
+     name="Test4",
+     source=FileScope.LOCAL,
+     steps=[]),
+   },
+  {"id": "saved_global_from_source",
+   "template": TemplateModel(
+     id="test5",
+     name="Test5",
+     source=FileScope.GLOBAL,
+     steps=[]),
+   },
+]
+@pytest.mark.parametrize("case", get_model_template_save_CASES, ids=[c["id"] for c in get_model_template_save_CASES])
+def test_model_template_save(monkeypatch, tmp_path, case):
+  global_dir = tmp_path / "home"
+  local_dir = tmp_path / "local"
+  global_dir.mkdir()
+  local_dir.mkdir()
+  monkeypatch.setattr(Path, "home", lambda: global_dir)
+  monkeypatch.setattr(Path, "cwd", lambda: local_dir)
+  template = case.get("template")
+  if case.get("expected_exception"):
+    with pytest.raises(case.get("expected_exception")):
+      template.save(case.get("location"))
+  else:
+    template.save(case.get("location"))
+    if case.get("location") == FileScope.LOCAL or (not case.get("location") and template.source == FileScope.LOCAL):
+      test_file = local_dir / ".prich" / "templates" / template.id / f"{template.id}.yaml"
+      assert test_file.exists()
+      test_file.unlink()
+    elif case.get("location") == FileScope.GLOBAL or (not case.get("location") and template.source == FileScope.GLOBAL):
+      test_file = global_dir / ".prich" / "templates" / template.id / f"{template.id}.yaml"
+      assert test_file.exists()
+      test_file.unlink()
+
+
+get_model_config_CASES = [
+  {"id": "wrong_param", "location": None, "expected_exception": click.ClickException, "expected_exception_text": "Save config location param value is not supported"},
+  {"id": "save_local", "location": FileScope.LOCAL},
+  {"id": "save_global", "location": FileScope.GLOBAL},
+]
+@pytest.mark.parametrize("case", get_model_config_CASES, ids=[c["id"] for c in get_model_config_CASES])
+def test_model_config(tmp_path, monkeypatch, basic_config, case):
+  global_dir = tmp_path / "home"
+  local_dir = tmp_path / "local"
+  global_dir.mkdir()
+  local_dir.mkdir()
+  monkeypatch.setattr(Path, "home", lambda: global_dir)
+  monkeypatch.setattr(Path, "cwd", lambda: local_dir)
+
+  if case.get("expected_exception") is not None:
+    with pytest.raises(case.get("expected_exception")) as e:
+      basic_config.save(case.get("location"))
+    if case.get("expected_exception_text") is not None:
+      if case.get("expected_exception") == click.ClickException:
+        assert case.get("expected_exception_text") in e.value.message
+      else:
+        assert case.get("expected_exception_text") in str(e.value)
+  else:
+    basic_config.save(case.get("location"))
+    saved_into_dir = global_dir if case.get("location") == FileScope.GLOBAL else local_dir
+    assert (saved_into_dir / ".prich" / "config.yaml").exists()
+    basic_config.save(case.get("location"))
+    assert (saved_into_dir / ".prich" / "config.yaml").exists()
+    assert (saved_into_dir / ".prich" / "config.bak").exists()

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+import pytest
+from click.testing import CliRunner
+
+get_validate_template_CASES = [
+    {"id": "local_and_global_params", "args": ["-g", "-l"], "expected_output": "Error: Use only one local or global option"},
+    {"id": "file_with_local_param", "args": ["--file", "test.yaml", "-l"], "expected_output": "When YAML file is selected it doesn't combine with local, global, or id options"},
+    {"id": "file_with_global_param", "args": ["--file", "test.yaml", "-g"], "expected_output": "When YAML file is selected it doesn't combine with local, global, or id options"},
+    {"id": "file_with_template_id_param", "args": ["--file", "test.yaml", "--id", "test-template"], "expected_output": "When YAML file is selected it doesn't combine with local, global, or id options"},
+    {"id": "file_not_present", "args": ["--file", "test.yaml"], "expected_output": "Failed to find test.yaml template file."},
+    {"id": "no_templates_found", "args": [], "expected_output": "No Templates found."},
+    {"id": "no_template_if_found", "args": ["--id", "test-template"], "expected_output": " Failed to find template with id: test-template"},
+]
+@pytest.mark.parametrize("case", get_validate_template_CASES, ids=[c["id"] for c in get_validate_template_CASES])
+def test_validate_template(tmp_path, monkeypatch, case):
+    from prich.cli.validate import validate_templates
+
+    global_dir = tmp_path / "home"
+    local_dir = tmp_path / "local"
+    global_dir.mkdir()
+    local_dir.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: global_dir)
+    monkeypatch.setattr(Path, "cwd", lambda: local_dir)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        result = runner.invoke(validate_templates, case.get("args"))
+        if case.get("expected_output") is not None:
+            assert case.get("expected_output") in result.output


### PR DESCRIPTION
Adding five new test modules (`test_init.py`, `test_listing.py`, `test_loaders.py`, `test_models.py`, `test_validate.py`) and a handful of helper functions in the test‑generation code.  
