### PR TITLE
update python and command step execution; move reserved options

### DIFF
--- a/prich/constants.py
+++ b/prich/constants.py
@@ -1,0 +1,6 @@
+# Reserved CLI options that are used by 'prich run' command
+# and are not allowed to be user/defined in the template variables cli_option
+RESERVED_RUN_TEMPLATE_CLI_OPTIONS = [
+    "-g", "--global", "-q", "--quiet", "-o", "--output", "-p", "--provider",
+    "-f", "--only-final-output", "-s", "--skip-llm", "-v", "--verbose"
+]

--- a/prich/core/utils.py
+++ b/prich/core/utils.py
@@ -30,6 +30,7 @@ def is_only_final_output() -> bool:
     return any(flag in sys.argv for flag in ("-f", "--only-final-output"))
 
 def is_piped() -> bool:
+    """ Check if prich executed with a piped command (should work only when not executed from pytest) """
     return not console.is_terminal and not os.getenv("PYTEST_CURRENT_TEST")
 
 def console_print(message: str = "", end: str = "\n", markup = None, flush: bool = None):
@@ -47,11 +48,18 @@ def is_valid_variable_name(variable_name) -> bool:
     pattern = r'^[A-Za-z0-9]+([_A-Za-z0-9]+)*$'
     return bool(re.match(pattern, variable_name))
 
+def is_cli_option_name(option_name) -> bool:
+    """ Validate CLI Option Name Pattern: lowercase letters, numbers, optional underscores, and no other characters"""
+    pattern = r'^--[a-z0-9]+([-_a-z0-9]+)*$'
+    return bool(re.match(pattern, option_name))
+
 def get_prich_dir(global_only: bool = None) -> Path:
+    """ Return current prich dir path based on global_only param or should_use_global_only() """
     parent_path = Path.home() if global_only or should_use_global_only() else Path.cwd()
     return parent_path / ".prich"
 
 def get_prich_templates_dir(global_only: bool = None) -> Path:
+    """ Return current prich templates folder path based on global_only param or should_use_global_only() """
     return get_prich_dir(global_only) / "templates"
 
 def replace_env_vars(text) -> str:
@@ -83,8 +91,16 @@ def replace_env_vars(text) -> str:
     return re.sub(env_pattern, replace_match, text)
 
 def shorten_home_path(path: str) -> str:
+    """ Return short path using ~/... instead of a full absolute path """
     home = str(Path.home())
     path = str(path)
     if path.startswith(home):
         return path.replace(home, "~", 1)
     return path
+
+def is_just_filename(filename: Path | str):
+    """ Check if filename is just a basename, not a path """
+    s = str(filename)
+    if s in ("", ".", "..") or ("/" in s) or ("\\" in s):
+        return False
+    return True


### PR DESCRIPTION
1. **New Constants File**  
   - A new file `prich/constants.py` defines `RESERVED_RUN_TEMPLATE_CLI_OPTIONS`, which lists CLI options reserved for the `prich run` command. This centralizes these options for reuse across the codebase.

2. **Refactored Venv Handling**  
   - The `run_command_step` function in `engine.py` simplifies venv logic by consolidating checks for `shared`, `isolated`, and `None` into a single block. It also updates error messages for clarity and adds a fallback to system Python when `template.venv` is `None`.

3. **Enhanced Command Step Logic**  
   - The command step now uses `is_just_filename` to determine if a method is a standalone filename, improving flexibility by resolving paths relative to the template directory.

4. **New Utility Functions**  
   - `prich/core/utils.py` adds:  
     - `is_cli_option_name`: Validates CLI option naming conventions.  
     - `is_just_filename`: Checks if a filename is a basename (not a full path).  
     - Improved docstrings and path shortening logic for `get_prich_dir`.

5. **Error Handling Improvements**  
   - Error messages are updated for consistency (e.g., "Execution error" instead of "Script error").  
   - A new check in `run_template` raises an error if no steps are found in a template.
