### PR TITLE
strict fields check in models and improved template model validation

### DIFF
--- a/prich/models/config.py
+++ b/prich/models/config.py
@@ -3,7 +3,7 @@ import os
 import click
 from pathlib import Path
 from typing import List, Optional, Literal, Dict, Annotated, Union
-from pydantic import BaseModel, Field, field_validator, TypeAdapter
+from pydantic import BaseModel, Field, field_validator, TypeAdapter, ConfigDict
 from prich.models.file_scope import FileScope
 from prich.models.config_providers import EchoProviderModel, OpenAIProviderModel, MLXLocalProviderModel, STDINConsumerProviderModel, OllamaProviderModel
 from prich.version import CONFIG_SCHEMA_VERSION
@@ -21,20 +21,24 @@ ProviderConfig = Annotated[
 
 
 class SecurityConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
     allowed_environment_variables: Optional[List[str]] = None
 
 
 class SettingsConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
     default_provider: str
     provider_assignments: Optional[Dict[str, str]] = None
     editor: Optional[str] = None
 
 
 class ProviderModeModel(BaseModel):
+    model_config = ConfigDict(extra='forbid')
     name: str
     prompt: str
 
 class ConfigModel(BaseModel):
+    model_config = ConfigDict(extra='forbid')
     schema_version: Literal["1.0"] = CONFIG_SCHEMA_VERSION
     providers: Dict[str, ProviderConfig]
     provider_modes: List[ProviderModeModel]

--- a/prich/models/config_providers.py
+++ b/prich/models/config_providers.py
@@ -1,8 +1,9 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 from typing import Literal, Optional, List, Tuple
 
 
 class BaseProviderModel(BaseModel):
+    model_config = ConfigDict(extra='forbid')
     name: str | None = Field(default=None, exclude=True)  # will be injected
     mode: Optional[str] = None
 


### PR DESCRIPTION
### **Summary of Git Diff Changes**  
The commit introduces `ConfigDict(extra='forbid')` to multiple Pydantic models across `config.py`, `config_providers.py`, and `template.py`. This enforces **strict schema validation** by disallowing any extra fields in these models. Key changes include:  
- Adding `model_config = ConfigDict(extra='forbid')` to classes like `SecurityConfig`, `SettingsConfig`, `BaseProviderModel`, `VariableDefinition`, `TemplateModel`, and others.  
- Enhancing validation logic in `TemplateModel` to check variable names, CLI option names, and default value types.  

---

### **Detailed Review**  
#### **1. Core Change: Strict Schema Enforcement**  
- **Purpose**: The addition of `ConfigDict(extra='forbid')` ensures that all models strictly adhere to their defined schemas. This prevents unexpected fields from being accepted, improving type safety and data integrity.  
- **Impact**:  
  - **Pros**:  
    - Reduces runtime errors from invalid data.  
    - Makes the codebase more robust and easier to maintain.  
  - **Cons**:  
    - Existing code that relies on dynamic field handling (e.g., legacy APIs or external integrations) may require updates.  

#### **2. Enhanced Validation in `TemplateModel`**  
- **Key Improvements**:  
  - **Variable Name Validation**: Ensures variable names follow regex rules (letters, underscores, numbers).  
  - **CLI Option Name Checks**:  
    - Auto-generates CLI options from variable names (e.g., `--variable-name`).  
    - Validates CLI options against reserved names (e.g., `--help`).  
  - **Default Value Type Checks**: Ensures default values match the declared type (e.g., `str`, `list[str]`, `path`).  
- **Potential Risks**:  
  - If the `is_cli_option_name` or `is_valid_variable_name` utilities are not robust, this could introduce false positives/negatives.  
  - The `RESERVED_RUN_TEMPLATE_CLI_OPTIONS` list must be kept up-to-date to avoid conflicts.  

#### **3. Consistency Across Models**  
- The change is applied uniformly across multiple models, which is a **good practice** for maintaining consistency. However, ensure that **all models requiring strict validation** have `ConfigDict(extra='forbid')` and that **no models should allow extra fields** are left without it.  

#### **4. Pydantic Best Practices**  
- **`ConfigDict(extra='forbid')`**: Correct usage for enforcing schema rigidity.  
- **`field_validator` vs `model_validator`**: Ensure that custom validation logic (e.g., CLI option checks) uses the appropriate Pydantic decorator (`field_validator` for fields, `model_validator` for model-wide checks).  