### PR TITLE
Venv changes

### DIFF
--- a/prich/cli/config.py
+++ b/prich/cli/config.py
@@ -1,12 +1,12 @@
 import os
 import click
 from pathlib import Path
-from prich.core.utils import shorten_home_path
+from prich.core.utils import shorten_path
 from prich.core.loaders import get_loaded_config, load_local_config, load_global_config
 from prich.core.utils import console_print
 
 def _readable_paths(paths: list[Path]):
-    return [f"[green]{shorten_home_path(str(p))}[/green]" for p in paths]
+    return [f"[green]{shorten_path(str(p))}[/green]" for p in paths]
 
 @click.group("config")
 def config_group():
@@ -65,7 +65,7 @@ def edit_config(global_only: bool, local_only: bool):
     elif global_config and global_path:
         config, path = global_config, global_path
     if not config:
-        raise click.ClickException(f"No config file found {shorten_home_path(str(path))}. Please check your configuration or run init.")
+        raise click.ClickException(f"No config file found {shorten_path(str(path))}. Please check your configuration or run init.")
     editor_cmd = config.settings.editor if config.settings and config.settings.editor else os.getenv("EDITOR", "vi")
     console_print(f"Executing: {editor_cmd} {str(path)}")
     subprocess.run([editor_cmd, str(path)], check=True, stdout=None)

--- a/prich/cli/templates.py
+++ b/prich/cli/templates.py
@@ -1,28 +1,35 @@
 import os
 import shutil
+import tempfile
+
 import yaml
 import subprocess
 from pathlib import Path
 import click
-import venv
 
-from prich.core.utils import shorten_home_path
 from prich.core.loaders import get_loaded_templates, get_loaded_config, get_loaded_template
+from prich.core.utils import console_print, is_valid_template_id, get_prich_dir, get_prich_templates_dir, shorten_path
+from prich.cli.venv_utils import install_template_python_dependencies
 from prich.models.template import TemplateModel, VariableDefinition, LLMStep, PromptFields
-from prich.core.utils import console_print, is_valid_template_id, get_prich_dir, get_prich_templates_dir
 
 def _download_zip(url: str) -> Path:
     """ Download zip file into temporary file and return path to it """
     import tempfile
-    import requests
     with tempfile.NamedTemporaryFile(delete=False, suffix=".zip") as tmp:
-        response = requests.get(url, stream=True)
-        response.raise_for_status()
+        return _download_file(url, tmp.name)
+
+def _download_file(url: str, dest_file: str | Path) -> Path:
+    import requests
+    if type(dest_file) == str:
+        dest_file = Path(dest_file)
+    dest_file.parent.mkdir(parents=True, exist_ok=True)
+    response = requests.get(url, stream=True)
+    response.raise_for_status()
+    with open(dest_file, "wb") as save_to_file:
         for chunk in response.iter_content(chunk_size=8192):
-            tmp.write(chunk)
-        tmp.flush()
-        tmp_path = Path(tmp.name)
-    return tmp_path
+            save_to_file.write(chunk)
+        save_to_file.flush()
+    return dest_file
 
 def _extract_zip(path: Path) -> Path:
     """ Extract zip archive into temporary folder and return path of it """
@@ -48,7 +55,7 @@ def check_if_dest_present(template_id: str, dest_folder: Path, global_install: b
     if dest_folder.exists() and not force:
         scope = "global" if global_install else "local"
         raise click.ClickException(
-            f"Template '{template_id}' already exists in {scope} directory ({dest_folder}). Use --force to overwrite.")
+            f"Template '{template_id}' already exists in {scope} directory ({shorten_path(str(dest_folder))}). Use --force to overwrite.")
 
 
 @click.command("install")
@@ -56,49 +63,71 @@ def check_if_dest_present(template_id: str, dest_folder: Path, global_install: b
 @click.option("--force", is_flag=True, help="Overwrite existing templates")
 @click.option("--no-venv", is_flag=True, help="Skip venv setup")
 @click.option("-g", "--global", "global_install", is_flag=True, help="Install to ~/.prich/templates")
-@click.option("-r", "--remote", "from_remote", is_flag=True, help="Install template from prich-templates GitHub repo")
+@click.option("-r", "--remote", "from_remote", is_flag=True, help="Install template from prich-templates GitHub repo or zip URL")
 def template_install(path: str, force: bool, no_venv: bool, global_install: bool, from_remote: bool):
     """Install a template from PATH, zip, or prich-templates."""
     from rich.console import Console
+    from prich.cli.template_utils import get_remote_prich_templates_manifest
     console = Console()
     templates_dir = get_prich_templates_dir(global_install)
     src_dir = None
     remove_source = False
 
     if from_remote:
-        if not is_valid_template_id(path):
-            raise click.ClickException(f"Remote Template ID {path} is not valid.")
-        check_if_dest_present(path, templates_dir / path, global_install, force)
+        if path.startswith("http://") or path.startswith("https://"):
+            if not path.endswith(".zip"):
+                raise click.ClickException(f"Remote URL should point to a zip file.")
+            from_url = path
 
-        from_url = f"https://raw.githubusercontent.com/oleks-dev/prich-templates/main/dist/{path}.zip"
-        try:
-            with console.status(f"Downloading {path} from {from_url}..."):
-                tmp_zip_file = _download_zip(
-                    url = from_url
-                )
-        except Exception as e:
-            safe_remove(tmp_zip_file)
-            raise click.ClickException(f"Failed to download template {path} from prich-templates, check if the template is available.")
+            try:
+                tmp_zip_file = None
+                with console.status(f"Downloading {path} from {from_url}..."):
+                    tmp_zip_file = _download_zip(
+                        url=from_url
+                    )
+            except Exception as e:
+                if tmp_zip_file and tmp_zip_file.exists():
+                    safe_remove(tmp_zip_file)
+                raise click.ClickException(
+                    f"Failed to download template {path}, check if the template is available in the remote.")
+            path = str(tmp_zip_file)
+
+        else:
+            if not is_valid_template_id(path):
+                raise click.ClickException(f"Remote Template ID {path} is not valid.")
+            check_if_dest_present(path, templates_dir / path, global_install, force)
+
+            with console.status("Fetching templates manifest..."):
+                templates_manifest = get_remote_prich_templates_manifest()
+            if not path in [x.id for x in templates_manifest.templates]:
+                raise click.ClickException(f"Remote Template ID {path} not found in the repository {templates_manifest.repository}.")
+            template_to_install = [x for x in templates_manifest.templates if x.id == path][0]
+            tmp_path = Path(tempfile.mkdtemp())
+            with console.status("Downloading..."):
+                for file_to_download in template_to_install.files:
+                    remote_templates_repo_path = "https://raw.githubusercontent.com/oleks-dev/prich-templates/refs/heads/main/templates/"
+                    download_to_file = tmp_path / file_to_download
+                    _download_file(f"{remote_templates_repo_path}{file_to_download}", download_to_file)
+            # TODO: drop folder name from manifest files
+            path = str(tmp_path)
+
+        remove_source = True
+
+    if path.endswith(".zip"):
         try:
             with console.status(f"Extracting..."):
-                src_dir = _extract_zip(tmp_zip_file)
-                safe_remove(tmp_zip_file)
-        except Exception as e:
-            safe_remove(tmp_zip_file)
-            raise click.ClickException(f"Failed to extract downloaded template {tmp_zip_file}")
-        remove_source = True
-    elif path.endswith(".zip"):
-        template_id = path[:-4]
-        check_if_dest_present(template_id, templates_dir / template_id, global_install, force)
-        try:
-            src_dir = _extract_zip(Path(path))
+                src_dir = _extract_zip(Path(path))
         except Exception as e:
             safe_remove(src_dir)
             raise click.ClickException(f"Failed to extract template {path}")
         remove_source = True
+
     else:
-        src_dir = Path(path).resolve()
-        if not src_dir.is_dir():
+        try:
+            src_dir = Path(path).resolve()
+        except Exception as e:
+            src_dir = None
+        if (src_dir and not src_dir.is_dir()) or not src_dir:
             raise click.ClickException(f"Path is not a directory: {path}")
 
     if not src_dir:
@@ -110,103 +139,83 @@ def template_install(path: str, force: bool, no_venv: bool, global_install: bool
             safe_remove(src_dir)
         raise click.ClickException("No template YAML found")
 
-    template_yaml = yaml_files[0]
-    template_content = yaml.safe_load(template_yaml.read_text())
-    template = TemplateModel(**template_content)
-    template_id = template.id
-    template_base = templates_dir / template_id
-    dest_yaml = template_base / f"{template_id}.yaml"
+    template = None
+    template_id = None
+    template_folder = None
+    yaml_files_issues = []
+    for template_yaml in yaml_files:
+        try:
+            template_content = yaml.safe_load(template_yaml.read_text())
+            if not template_content:
+                yaml_files_issues.append(f"File {shorten_path(str(template_yaml))} is empty")
+                continue
+            template = TemplateModel(**template_content)
+            template_id = template.id
+            template_folder = templates_dir / template_id
+            break
+        except Exception as e:
+            yaml_files_issues.append(f"File {shorten_path(str(template_yaml))}: {str(e)}")
+    if not template and not template_id and not template_folder:
+        yaml_error_list = "\n ".join(yaml_files_issues)
+        raise click.ClickException(f"Failed to load template:\n{yaml_error_list}")
 
-    check_if_dest_present(template_id, template_base, global_install, force)
+    check_if_dest_present(template_id, template_folder, global_install, force)
 
-    os.makedirs(template_base, exist_ok=True)
-    # if not no_yaml:
-    shutil.copy(template_yaml, dest_yaml)
+    console_print(f"Installing template to {shorten_path(str(template_folder))}:")
+    os.makedirs(template_folder, exist_ok=True)
+    shutil.copytree(src_dir, template_folder, dirs_exist_ok=True)
+    template_files = list(template_folder.glob("**/*"))
+    template_files.sort()
+    for template_file in template_files:
+        console_print(f" + {str(template_file).replace(str(template_folder), '.')}")
 
-    src_scripts = src_dir / "scripts"
-    if src_scripts.exists():
+    sh_files = list((template_folder / "scripts").glob("**/*.sh"))
+    if sh_files:
         console_print("Setup Scripts:")
-        dest_scripts = template_base / "scripts"
-        os.makedirs(dest_scripts, exist_ok=True)
-        console_print("Copying...")
-        for script in src_scripts.glob("*"):
-            dest_script = dest_scripts / script.name
-            console_print(f"  - {script.name}")
-            shutil.copy(script, dest_script)
-            # Set 755 to shell scripts
-            if str(script).endswith(".sh"):
-                response = input(f"Set {script} as executable [y/n]? ")
-                if response.lower() in ['y', 'yes']:
-                    console_print(f"Running chmod {script} 755")
-                    dest_script.chmod(0o755)
-        console_print("[green]Done![/green]")
+        for sh_file in sh_files:
+            response = input(f"Set {str(sh_file).replace(str(template_folder), '')} as 755 executable [y/n]? ")
+            if response.lower() in ['y', 'yes']:
+                console_print(f"Running chmod 755...", end='')
+                sh_file.chmod(0o755)
+                if sh_file.lchmod(0o755):
+                    console_print(f" done.")
+                else:
+                    console_print(f" failed.")
+            else:
+                console_print("Skipped chmod 755.")
+
+    console_print("[green]Done![/green]")
 
     if remove_source:
         safe_remove(src_dir)
 
     if not no_venv and template.venv:
-        install_template_venv(template=template, force=force, template_base=template_base)
+        install_template_venv(template=template, force=force, template_base=template_folder)
 
-    console_print(f"Template [green]{template_id}[/green] installed successfully")
-    console_print(f"Run: [cyan]prich[/cyan] run [green]{template_id}[/green] --help")
+    console_print()
+    console_print(f"Template [green]{template_id}[/green] installed successfully.")
+    console_print(f"Run: [cyan]prich[/cyan] run [green]{template_id}[/green]{' -g' if global_install else ''} --help")
+
 
 def install_template_venv(template: TemplateModel, template_base: Path = None, force: bool = False):
+    """Install Python venv for a template"""
+    from prich.cli.venv_utils import install_python_venv
+
     if not template_base:
         template_base = Path(template.folder)
     scripts_folder = template_base / "scripts"
-    src_requirements = scripts_folder / "requirements.txt"
     if template.venv == "isolated":
         template_venv = scripts_folder / "venv"
-        if template_venv.exists() and force:
-            console_print(f"Removing existing venv {shorten_home_path(str(template_venv))}...", end="")
-            shutil.rmtree(template_venv)
-            console_print(" [green]done![/green]")
-        if not template_venv.exists():
-            console_print(f"Creating folder {shorten_home_path(str(template_venv))}...", end="")
-            os.makedirs(template_venv, exist_ok=True)
-            console_print(" [green]done![/green]")
-            console_print(f"Installing isolated venv...", end="")
-
-            # Install venv
-            try:
-                builder = venv.EnvBuilder(with_pip=True)
-                builder.create(template_venv)
-                # Optional Install venv using cmd
-                # subprocess.run([sys.executable, "-m", "venv", str(template_venv)], check=True)
-            except Exception as e:
-                console_print()
-                raise click.ClickException(f"Failed to install venv: {str(e)}")
-            console_print(" [green]done![/green]")
-        if src_requirements.exists():
-            console_print("Installing dependencies...")
-            pip_cmd = template_venv / "bin/pip"
-            if not pip_cmd.exists():
-                raise click.ClickException(f"No pip {shorten_home_path(str(pip_cmd))} found in isolated template venv.")
-            subprocess.run([str(pip_cmd), "install", "-r", str(src_requirements)], check=True)
-        else:
-            console_print(f"No dependencies {shorten_home_path(str(src_requirements))} file found in the template.")
+        install_python_venv(template_venv, force=force, venv_type="isolated")
+        install_template_python_dependencies(template_venv, template_base)
         console_print("[green]Done![/green]")
     elif template.venv == "shared":
         prich_dir = get_prich_dir()
         shared_venv = prich_dir / "venv"
         if shared_venv.exists() and force:
-            raise click.ClickException(f"Shared venv with --force is not supported as it might break other templates that uses shared venv, if you are sure that you want to do this you can remove {shorten_home_path(str(shared_venv))} folder manually and then execute this command again without --force option flag.")
-        if not shared_venv.exists():
-            console_print("No shared venv found, installing...")
-            try:
-                builder = venv.EnvBuilder(with_pip=True)
-                builder.create(shared_venv)
-            except Exception as e:
-                raise click.ClickException(f"Failed to install venv: {e}")
-            console_print(f"Shared venv installed: {shorten_home_path(str(shared_venv))}")
-        if src_requirements.exists():
-            console_print(f"Installing dependencies to shared venv:")
-            pip_cmd = shared_venv / "bin/pip"
-            if not pip_cmd.exists():
-                raise click.ClickException(f"No pip {shorten_home_path(str(pip_cmd))} found in shared venv.")
-            subprocess.run([pip_cmd, "install", "-r", str(src_requirements)], check=True)
-        else:
-            console_print(f"No dependencies {shorten_home_path(str(src_requirements))} file found in the template.")
+            raise click.ClickException(f"Shared venv with --force is not supported as it might break other templates that uses shared venv, if you are sure that you want to do this you can remove {shorten_path(str(shared_venv))} folder manually and then execute this command again without --force option flag.")
+        install_python_venv(shared_venv, venv_type="shared")
+        install_template_python_dependencies(shared_venv, template_base)
         console_print("[green]Done![/green]")
     else:
         console_print(f"Template {template.id} doesn't require venv. To setup venv add 'venv: \"isolated\"' or 'venv: \"shared\" into the template and rerun this command.'")
@@ -215,7 +224,7 @@ def install_template_venv(template: TemplateModel, template_base: Path = None, f
 @click.command("venv-install")
 @click.argument("template_id")
 @click.option("-g", "--global", "global_only", is_flag=True, help="Only global config")
-@click.option("-f", "--force", "force", is_flag=True, help="Remove venv and re-install")
+@click.option("-f", "--force", "force", is_flag=True, help="Re-install venv")
 def venv_install(template_id, global_only, force):
     """Install venv for Template with python script steps"""
     template = get_loaded_template(template_id)

--- a/prich/cli/validate.py
+++ b/prich/cli/validate.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import click
 from prich.core.file_scope import classify_path
 from prich.core.loaders import find_template_files, load_template_model
-from prich.core.utils import console_print, shorten_home_path
+from prich.core.utils import console_print, shorten_path
 
 
 @click.command(name="validate")
@@ -52,10 +52,10 @@ def validate_templates(template_id: str, validate_file: Path, global_only: bool,
     for template_file in template_files:
         try:
             template = load_template_model(template_file)
-            console_print(f"- {template.id} [dim]({template.source.value}) {shorten_home_path(str(template_file))}[/dim]: [green]is valid[/green]" )
+            console_print(f"- {template.id} [dim]({template.source.value}) {shorten_path(str(template_file))}[/dim]: [green]is valid[/green]")
         except click.ClickException as e:
             failures_found = True
             template_source = classify_path(template_file)
-            console_print(f"- [dim]({template_source.value}) {shorten_home_path(str(template_file))}[/dim]: [red]is not valid\n  {e.message.replace(f' from {template_file}', '')}[/red]")
+            console_print(f"- [dim]({template_source.value}) {shorten_path(str(template_file))}[/dim]: [red]is not valid[/red]\n  [red]{e.message.replace(f' from {template_file}', '')}[/red]")
     if failures_found:
         sys.exit(1)

--- a/prich/constants.py
+++ b/prich/constants.py
@@ -2,5 +2,5 @@
 # and are not allowed to be user/defined in the template variables cli_option
 RESERVED_RUN_TEMPLATE_CLI_OPTIONS = [
     "-g", "--global", "-q", "--quiet", "-o", "--output", "-p", "--provider",
-    "-f", "--only-final-output", "-s", "--skip-llm", "-v", "--verbose"
+    "-f", "--only-final-output", "-v", "--verbose"
 ]

--- a/prich/core/utils.py
+++ b/prich/core/utils.py
@@ -9,10 +9,24 @@ console = Console()
 
 def should_use_global_only() -> bool:
     """ Should only global config/templates used? """
+    try:
+        global_only_options = ["global_only", "global_init", "global_install"]
+        for global_ in global_only_options:
+            if click.get_current_context().params.get(global_):
+                return True
+    except:
+        pass
     return any(flag in sys.argv for flag in ("-g", "--global"))
 
 def should_use_local_only() -> bool:
     """ Should only local config/templates used? """
+    try:
+        local_only_options = ["local_only"]
+        for global_ in local_only_options:
+            if click.get_current_context().params.get(global_):
+                return True
+    except:
+        pass
     return any(flag in sys.argv for flag in ("-l", "--local"))
 
 def is_verbose() -> bool:
@@ -93,12 +107,16 @@ def replace_env_vars(text: str, secure: bool = True) -> str:
     env_pattern = r'\$(?:\{([^}]+)\}|([a-zA-Z_][a-zA-Z0-9_]*))'
     return re.sub(env_pattern, replace_match, text)
 
-def shorten_home_path(path: str) -> str:
-    """ Return short path using ~/... instead of a full absolute path """
+def shorten_path(path: str | Path) -> str:
+    """ Return short path using ~/... or ./... instead of a full absolute path """
     home = str(Path.home())
-    path = str(path)
+    cwd = str(Path.cwd())
+    if type(path) == Path:
+        path = str(path)
     if path.startswith(home):
         return path.replace(home, "~", 1)
+    elif path.startswith(cwd):
+        return path.replace(cwd, ".", 1)
     return path
 
 def is_just_filename(filename: Path | str):


### PR DESCRIPTION
- `shorten_path(path: str | Path)`: Now supports **both**:
  - **Home directory** abbreviations (`~`).
  - **Current working directory** abbreviations (`.`).
  - Example: `/home/user/docs` → `~/docs`, `/current/path/docs` → `.docs`.

- **Error Message Refinement**
  - Error messages now use **`shorten_path`** instead of `shorten_home_path`, improving readability for both local and global paths.

- **Class Renaming**: `StepValidation` → `ValidateStepOutput` for clarity and consistency.
  - A new `message` field allows for custom error messages during validation.
  - The `validate_` field in `BaseStepModel` is now a list of `ValidateStepOutput` objects, enabling multiple validation rules per step.

- **YAML Serialization Improvement for templates**
  - **`str_presenter`** ensures that **multi-line strings** are saved as block scalars in YAML, preserving formatting.
  - **`model_dump`** with `exclude_none=True` ensures cleaner YAML output by omitting `None` values.

- **Configuration Management Enhancements**
  - **`should_use_global_only`** and **`should_use_local_only`** now check **CLI parameters** via `click.get_current_context().params`, allowing dynamic configuration based on flags like `-g` or `-l`.

- **Template installation refactoring**
  - Templates now could be installed from local zip file or remote url
  - Remote templates price-templates repo installation changed from zip file to plain text to not store binary files in the repo separately.

- **Python venv installation refactoring**
  - venv and dependencies installations moved to a separate utility file
  - logic simplified and cleaned up

- **Clean up**
  - remove `skip-llm` option from template run as it is not having proper use cases

- **Console output on template runs**
  - Update coloring to make most service messages dimmed
  - Update when step outputs text to console depending on step `output_console` and verbose option flag 
