### PR TITLE
move output strip and slice from stdin consumer to all steps; update validate step readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ There are several commands that you can execute the check the templates:
 ## Configure .prich/config.yaml
 
 ### Settings
-```python
+```yaml
 settings:
   default_provider: "llama3.1-8b"
   editor: "vim"
@@ -538,9 +538,9 @@ settings:
       mode: Optional[str]  # Prompt Provider Mode (for prompt templates)
       call: Optional[str] = None  # command call for shell execution
       args: Optional[List[str]] = None  # arguments for shell execution
-      stdout_strip_prefix: Optional[str] = None  # strip prefix string from the response
-      stdout_slice_start: Optional[int] = None  # slice stdout from character number
-      stdout_slice_end: Optional[int] = None  # slice stdout to character number
+      strip_output_prefix: Optional[str] = None  # strip prefix string from the step output
+      slice_output_start: Optional[int] = None  # slice step output from character number
+      slice_output_end: Optional[int] = None  # slice step output to character number
     ```
   Example:
     ```yaml

--- a/prich/core/engine.py
+++ b/prich/core/engine.py
@@ -402,6 +402,14 @@ def run_template(template_id, **kwargs):
             else:
                 raise click.ClickException(f"Step {step.type} type is not supported.")
 
+            if step.strip_output_prefix or step.slice_output_start or step.slice_output_end:
+                if is_verbose():
+                    if step.strip_output_prefix:
+                        console_print(f"[dim]Strip output prefix: {step.strip_output_prefix}[/dim]")
+                    if step.slice_output_start or step.slice_output_end:
+                        console_print(f"[dim]Slice output text{f' from {step.slice_output_start}' if step.slice_output_start else ''}{f' to {step.slice_output_end}' if step.slice_output_end else ''}[/dim]")
+                step_output = step.strip_and_slice_output(step_output)
+
             # Store last output
             last_output = step_output
 

--- a/prich/llm_providers/stdin_consumer_provider.py
+++ b/prich/llm_providers/stdin_consumer_provider.py
@@ -10,17 +10,6 @@ class STDINConsumerProvider(LLMProvider):
         self.show_response: bool = False
 
     @staticmethod
-    def clean_stdout(text: str, *, strip_prefix=None, slice_range=None) -> str:
-        if strip_prefix and text.startswith(strip_prefix):
-            text = text[len(strip_prefix):]
-
-        if slice_range:
-            start, end = slice_range
-            text = text[start:end]
-
-        return text
-
-    @staticmethod
     def clear_ansi(text: str) -> str:
         import re
         return re.sub(r'\x1b\[[0-9;]*m', '', text)
@@ -42,9 +31,4 @@ class STDINConsumerProvider(LLMProvider):
         except Exception as e:
             raise click.ClickException(f"STDIN consumer provider error: {str(e)}")
         clean_output = self.clear_ansi(response.stdout)
-        clean_output = self.clean_stdout(
-            clean_output,
-            strip_prefix=self.provider.stdout_strip_prefix,
-            slice_range=(self.provider.stdout_slice_start, self.provider.stdout_slice_end) if self.provider.stdout_slice_start or self.provider.stdout_slice_end else None
-        )
         return clean_output

--- a/prich/models/config_providers.py
+++ b/prich/models/config_providers.py
@@ -54,9 +54,6 @@ class STDINConsumerProviderModel(BaseProviderModel):
     provider_type: Literal["stdin_consumer"]
     call: str = None
     args: Optional[List[str]] = None
-    stdout_strip_prefix: Optional[str] = None
-    stdout_slice_start: Optional[int] = None
-    stdout_slice_end: Optional[int] = None
 
 class OllamaProviderModel(BaseProviderModel):
     provider_type: Literal["ollama"]

--- a/prich/models/template.py
+++ b/prich/models/template.py
@@ -40,6 +40,9 @@ class ValidateStepOutput(BaseModel):
 class BaseStepModel(BaseModel):
     model_config = ConfigDict(extra='forbid')
     name: str
+    strip_output_prefix: Optional[str] = None
+    slice_output_start: Optional[int] = None
+    slice_output_end: Optional[int] = None
     output_variable: Optional[str | None] = None
     output_file: Optional[str | None] = None
     output_file_mode: Optional[Literal["write", "append"]] = None
@@ -47,6 +50,13 @@ class BaseStepModel(BaseModel):
     when: Optional[str | None] = None
     validate_: Optional[ValidateStepOutput | list[ValidateStepOutput]] = Field(alias="validate", default=None)
 
+    def strip_and_slice_output(self, text: str) -> str:
+        """Strip prefix text and/or Slice the output"""
+        if self.strip_output_prefix and text.startswith(self.strip_output_prefix):
+            text = text[len(self.strip_output_prefix):]
+        if self.slice_output_start or self.slice_output_end:
+            text = text[self.slice_output_start:self.slice_output_end]
+        return text
 
 class LLMStep(BaseStepModel):
     type: Literal["llm"]

--- a/templates_guide.md
+++ b/templates_guide.md
@@ -29,8 +29,11 @@ Each step defines an action for the template pipeline workflow executed in order
 * `output_variable`: save output of the execution into a variable for the following usage
 * `output_file`: save output of the execution into a file
 * `output_file_mode`: `write`/`append`
+* `strip_output_prefix`: strip prefix string from the step output
+* `slice_output_start`: slice step output from character number
+* `slice_output_end`: slice step output to character number
 * `when`: execute step only when true - simple jinja evaluation like `working_vs_last_commit or (not working_vs_last_commit and not working_vs_remote and not committed_vs_remote and not remote_vs_local)` or `not remote_vs_local`, etc.
-* `validation`: validate step execution (see `step validation`)
+* `validate`: validate step execution (see `step validate`)
 * plus additional keys based on the step type
 
 **Step `type`**:
@@ -75,10 +78,12 @@ Each step defines an action for the template pipeline workflow executed in order
         output_variable: "check_file_text"
     ```
 
-**Step `validation`**:
+**Step `validate`**:  
+Could be dict or a list of validations
 * `match`: regex to match output
 * `not_match`: regex not match output
 * `on_fail`: `error`/`warn`/`skip`/`continue` default is `error`
+* `message`: text message to show on failure
 
 
 ### Build a New Simple One-Step Template


### PR DESCRIPTION
**refactoring and renaming** of parameters related to output processing.

1. **Parameter Renaming**:
   - `stdout_strip_prefix` → `strip_output_prefix`
   - `stdout_slice_start` → `slice_output_start`
   - `stdout_slice_end` → `slice_output_end`
   - These changes align with a more descriptive naming convention for output processing.

2. **Code Structure Improvements**:
   - Removed redundant `clean_stdout` method in `stdin_consumer_provider.py` and moved its logic to `strip_and_slice_output` in `BaseStepModel`.
   - Added logging in `engine.py` to indicate when output processing (stripping/slicing) is applied.

3. **Documentation Updates**:
   - Updated `templates_guide.md` to reflect the new parameter names and renamed `validation` to `validate` in the step configuration.