### PR TITLE
add more tests for the coverage

### DIFF
--- a/tests/fixtures/paths.py
+++ b/tests/fixtures/paths.py
@@ -2,11 +2,24 @@ import shutil
 from dataclasses import dataclass
 from pathlib import Path
 
+from yaml import SafeLoader
+
+from prich.models.config import ConfigModel
+
+from prich.models.file_scope import FileScope
+from prich.core.state import _loaded_templates, _loaded_config, _loaded_config_paths
+from tests.fixtures.config import CONFIG_YAML
+
 import pytest
 
 
 @pytest.fixture
 def mock_paths(tmp_path, monkeypatch):
+    import yaml
+    _loaded_templates.clear()
+    _loaded_config = None
+    _loaded_config_paths = []
+    config = ConfigModel(**yaml.load(CONFIG_YAML, SafeLoader))
     home_dir = tmp_path / "home"
     cwd_dir = tmp_path / "local"
     global_prich_dir = home_dir / ".prich"
@@ -21,6 +34,8 @@ def mock_paths(tmp_path, monkeypatch):
     local_prich_templates_dir.mkdir(exist_ok=True)
     monkeypatch.setattr(Path, "home", lambda: home_dir)
     monkeypatch.setattr(Path, "cwd", lambda: cwd_dir)
+    config.save(FileScope.GLOBAL)
+    config.save(FileScope.LOCAL)
 
     @dataclass
     class PrichFolder:

--- a/tests/fixtures/templates.py
+++ b/tests/fixtures/templates.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from prich.models.file_scope import FileScope
 
 from prich.models.template import TemplateModel, VariableDefinition, PythonStep, LLMStep, PromptFields, CommandStep, \
-    StepValidation
+    ValidateStepOutput
 from tests.generate.templates import generate_template, templates
 
 
@@ -84,7 +84,7 @@ def template(tmp_path):
                 output_variable="llm_response",
                 output_file="test_llm_response.txt",
                 when="1==1",
-                validation=StepValidation(
+                validate=ValidateStepOutput(
                     match=".+",
                     not_match="^not match"
                 )
@@ -128,7 +128,7 @@ def shared_venv_template(tmp_path):
                 args=["test"],
                 output_file="echo_output.txt",
                 output_variable="test_output_echo",
-                validation=StepValidation(match=".+", not_match="^not")
+                validate=ValidateStepOutput(match=".+", not_match="^not")
             ),
             PythonStep(
                 name="Preprocess python",
@@ -186,5 +186,15 @@ def temp_template_dir():
     template_dir.mkdir()
     (template_dir / "test_template.yaml").write_text(TEMPLATE_YAML)
     yield template_dir
+
+    shutil.rmtree(temp_dir)
+
+@pytest.fixture
+def temp_empty_dir():
+    temp_dir = Path(tempfile.mkdtemp())
+    template_dir = temp_dir / "test_emtpy"
+    template_dir.mkdir()
+    yield {"name": "test_emtpy",
+           "folder": template_dir}
 
     shutil.rmtree(temp_dir)

--- a/tests/generate/templates.py
+++ b/tests/generate/templates.py
@@ -21,7 +21,7 @@ def generate_template(prich_path: Path = Path("./test"), template_id: str=None, 
         author=faker.name(),
         name=tpl_name,
         description=tpl_description,
-        tags=[faker.word(ext_word_list=tpl_description.replace(",", "").replace(".", "").split(" ")).lower()],
+        tags=[faker.word(ext_word_list=tpl_description.replace(",", "").replace(".", "").replace("\n", " ").split(" ")).lower()],
         variables=[
             VariableDefinition(
                 name="name",

--- a/tests/test_dcg_n_main.py
+++ b/tests/test_dcg_n_main.py
@@ -1,0 +1,29 @@
+import pytest
+from click import Context, Command
+
+from prich.cli.dynamic_command_group import DynamicCommandGroup
+
+
+def test_dcg():
+    """Just to call the methods"""
+    cmd = Command(None)
+    ctx = Context(cmd)
+    dcg = DynamicCommandGroup(None)
+    dcg.list_commands(ctx)
+    dcg.get_command(ctx, "test")
+    dcg._load_dynamic_commands(ctx)
+
+def test_main_add_commands():
+    import prich.cli.main
+
+def test_optional_import():
+    from prich.core.optional_imports import ensure_optional_dep
+    ensure_optional_dep("requests")
+    with pytest.raises(RuntimeError):
+        ensure_optional_dep("notexistingone")
+
+def test_lazy_import():
+    from prich.llm_providers.base_optional_provider import LazyOptionalProvider
+    lop = LazyOptionalProvider()
+    lop._lazy_import("requests")
+    lop._lazy_import_from("openai", "OpenAI")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -8,7 +8,7 @@ import pytest
 from pathlib import Path
 
 from prich.models.config import SecurityConfig
-from prich.models.template import PromptFields, StepValidation, PythonStep, CommandStep, VariableDefinition
+from prich.models.template import PromptFields, ValidateStepOutput, PythonStep, CommandStep, VariableDefinition
 from prich.core.loaders import load_config_model
 from prich.core.engine import render_prompt, render_template
 from tests.fixtures.config import basic_config, basic_config_with_prompts, CONFIG_YAML
@@ -352,22 +352,22 @@ get_validate_sep_output_CASES = [
      "expected_result": True,
      },
     {"id": "empty_stepvalidation",
-     "step_validation": StepValidation(),
+     "step_validation": ValidateStepOutput(),
      "value": "test",
      "expected_result": True,
      },
     {"id": "match",
-     "step_validation": StepValidation(match=".+"),
+     "step_validation": ValidateStepOutput(match=".+"),
      "value": "test",
      "expected_result": True,
      },
     {"id": "not_match_startfrom",
-     "step_validation": StepValidation(not_match="^te"),
+     "step_validation": ValidateStepOutput(not_match="^te"),
      "value": "test123",
      "expected_result": False,
      },
     {"id": "match_startfrom",
-     "step_validation": StepValidation(match="^te"),
+     "step_validation": ValidateStepOutput(match="^te"),
      "value": "test123",
      "expected_result": True,
      },

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,28 +5,24 @@ import click
 import pydantic
 import pytest
 from prich.models.file_scope import FileScope
-
-from prich.models.template import TemplateModel
-
+from prich.models.template import TemplateModel, PythonStep
 from prich.models.template_repo_manifest import TemplatesRepoManifest
 from tests.fixtures.config import basic_config
 
 def test_model_template_repo_manifest():
     test_repo = {
-      "archives_path": "https://github.com/oleks-dev/prich-templates/tree/main/dist",
       "templates_path": "https://github.com/oleks-dev/prich-templates/tree/main/templates",
+      "templates_download_path": "https://raw.githubusercontent.com/oleks-dev/prich-templates/refs/heads/main/templates",
       "description": "Templates Available for Installation from prich-templates GitHub Repository",
       "name": "prich Templates",
       "repository": "https://github.com/oleks-dev/prich-templates",
       "schema_version": "1.0",
       "templates": [
         {
-          "archive": "cli-expert.zip",
-          "archive_checksum": "38c5def03643406f9844e1dde12c2fa69eaa6f570aa1d510f90d682dd5f05a12",
           "author": "prich",
           "description": "CLI command usage helper providing real-world examples for shell commands across different operating systems.",
           "files": [
-            "cli-expert/cli-expert.yaml"
+            "cli-expert.yaml"
           ],
           "folder_checksum": "f9b55f89d3b6ec28aff63665c1e410689a9f3f7f09b7bde0eada49f5be6259e6",
           "id": "cli-expert",
@@ -90,6 +86,10 @@ get_model_template_CASES = [
         "name": "Test",
         "schema_version": "1.0",
         "steps": [
+            {"name": "step1",
+             "call": "",
+             "args": [],
+             "type": "command"},
         ],
         "variables": [
           {"name": "wrong-variable-name"}
@@ -105,6 +105,10 @@ get_model_template_CASES = [
         "name": "Test",
         "schema_version": "1.0",
         "steps": [
+            {"name": "step1",
+             "call": "",
+             "args": [],
+             "type": "command"},
         ],
         "variables": [
           {"name": "Wrong_variable_for_option"}
@@ -120,6 +124,10 @@ get_model_template_CASES = [
         "name": "Test",
         "schema_version": "1.0",
         "steps": [
+            {"name": "step1",
+             "call": "",
+             "args": [],
+             "type": "command"},
         ],
         "variables": [
           {"name": "variable_name",
@@ -136,6 +144,10 @@ get_model_template_CASES = [
         "name": "Test",
         "schema_version": "1.0",
         "steps": [
+            {"name": "step1",
+             "call": "",
+             "args": [],
+             "type": "command"},
         ],
         "variables": [
           {"name": "global"}
@@ -151,6 +163,10 @@ get_model_template_CASES = [
         "name": "Test",
         "schema_version": "1.0",
         "steps": [
+            {"name": "step1",
+             "call": "",
+             "args": [],
+             "type": "command"},
         ],
         "variables": [
           {"name": "test_var",
@@ -167,6 +183,10 @@ get_model_template_CASES = [
         "name": "Test",
         "schema_version": "1.0",
         "steps": [
+            {"name": "step1",
+             "call": "",
+             "args": [],
+             "type": "command"},
         ],
         "variables": [
           {"name": "test_var",
@@ -185,6 +205,10 @@ get_model_template_CASES = [
         "name": "Test",
         "schema_version": "1.0",
         "steps": [
+            {"name": "step1",
+             "call": "",
+             "args": [],
+             "type": "command"},
         ],
         "variables": [
           {"name": "test_var",
@@ -203,6 +227,10 @@ get_model_template_CASES = [
         "name": "Test",
         "schema_version": "1.0",
         "steps": [
+            {"name": "step1",
+             "call": "",
+             "args": [],
+             "type": "command"},
         ],
         "variables": [
           {"name": "test_var",
@@ -219,6 +247,10 @@ get_model_template_CASES = [
         "name": "Test",
         "schema_version": "1.0",
         "steps": [
+            {"name": "step1",
+             "call": "",
+             "args": [],
+             "type": "command"},
         ],
         "variables": [
           {"name": "file",
@@ -235,6 +267,10 @@ get_model_template_CASES = [
         "name": "Test",
         "schema_version": "1.0",
         "steps": [
+            {"name": "step1",
+             "call": "",
+             "args": [],
+             "type": "command"},
         ],
         "variables": [
           {"name": "bool",
@@ -251,6 +287,10 @@ get_model_template_CASES = [
         "name": "Test",
         "schema_version": "1.0",
         "steps": [
+            {"name": "step1",
+             "call": "",
+             "args": [],
+             "type": "command"},
         ],
         "variables": [
           {"name": "text",
@@ -275,74 +315,90 @@ get_model_template_CASES = [
 ]
 @pytest.mark.parametrize("case", get_model_template_CASES, ids=[c["id"] for c in get_model_template_CASES])
 def test_model_template(case):
-  if case.get("expected_exception") is not None:
-    with pytest.raises(case.get("expected_exception")) as e:
-      TemplateModel(**case.get("data"))
+    if case.get("expected_exception") is not None:
+        with pytest.raises(case.get("expected_exception")) as e:
+            TemplateModel(**case.get("data"))
     if case.get("expected_exception_text") is not None:
-      if case.get("expected_exception") == click.ClickException:
-        assert case.get("expected_exception_text") in e.value.message
-      else:
-        assert case.get("expected_exception_text") in str(e.value)
-  else:
-    TemplateModel(**case.get("data"))
+        if case.get("expected_exception") == click.ClickException:
+            assert case.get("expected_exception_text") in e.value.message
+        else:
+            assert case.get("expected_exception_text") in str(e.value)
+    else:
+        TemplateModel(**case.get("data"))
 
 
 get_model_template_save_CASES = [
   {"id": "failed_to_save",
-   "template": TemplateModel(
-      id = "test1",
-      name = "Test1",
-      steps = []),
+   "template": {
+      "id": "test1",
+      "name": "Test1",
+      "steps": []},
    "location": None, "expected_exception": click.ClickException},
   {"id": "saved_local",
-   "template": TemplateModel(
-      id = "test2",
-      name = "Test2",
-      steps = []),
+   "template": {
+      "id": "test2",
+      "name": "Test2",
+      "steps": []},
    "location": FileScope.LOCAL},
   {"id": "saved_global",
-   "template": TemplateModel(
-     id="test3",
-     name="Test3",
-     steps=[]),
+   "template": {
+     "id": "test3",
+     "name": "Test3",
+     "steps": []},
    "location": FileScope.GLOBAL},
   {"id": "saved_local_from_source",
-   "template": TemplateModel(
-     id="test4",
-     name="Test4",
-     source=FileScope.LOCAL,
-     steps=[]),
+   "template": {
+     "id": "test4",
+     "name": "Test4",
+     "source": FileScope.LOCAL,
+     "steps": []},
    },
   {"id": "saved_global_from_source",
-   "template": TemplateModel(
-     id="test5",
-     name="Test5",
-     source=FileScope.GLOBAL,
-     steps=[]),
+   "template": {
+     "id": "test5",
+     "name": "Test5",
+     "source": FileScope.GLOBAL,
+     "steps": []},
    },
 ]
 @pytest.mark.parametrize("case", get_model_template_save_CASES, ids=[c["id"] for c in get_model_template_save_CASES])
 def test_model_template_save(monkeypatch, tmp_path, case):
-  global_dir = tmp_path / "home"
-  local_dir = tmp_path / "local"
-  global_dir.mkdir()
-  local_dir.mkdir()
-  monkeypatch.setattr(Path, "home", lambda: global_dir)
-  monkeypatch.setattr(Path, "cwd", lambda: local_dir)
-  template = case.get("template")
-  if case.get("expected_exception"):
-    with pytest.raises(case.get("expected_exception")):
-      template.save(case.get("location"))
-  else:
-    template.save(case.get("location"))
+    template = TemplateModel(
+        id="test-tpl",
+        name="Test TPL",
+        steps=[
+          PythonStep(
+              name="Preprocess python",
+              type="python",
+              call="echo.py",
+              args=["test"],
+              output_variable="test_var"
+          ),
+        ],
+    )
+
+    for k, v in case.get("template").items():
+        template.__setattr__(k, v)
+
+    global_dir = tmp_path / "home"
+    local_dir = tmp_path / "local"
+    global_dir.mkdir()
+    local_dir.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: global_dir)
+    monkeypatch.setattr(Path, "cwd", lambda: local_dir)
+    if case.get("expected_exception"):
+        with pytest.raises(case.get("expected_exception")):
+            template.save(case.get("location"))
+    else:
+        template.save(case.get("location"))
     if case.get("location") == FileScope.LOCAL or (not case.get("location") and template.source == FileScope.LOCAL):
-      test_file = local_dir / ".prich" / "templates" / template.id / f"{template.id}.yaml"
-      assert test_file.exists()
-      test_file.unlink()
+        test_file = local_dir / ".prich" / "templates" / template.id / f"{template.id}.yaml"
+        assert test_file.exists()
+        test_file.unlink()
     elif case.get("location") == FileScope.GLOBAL or (not case.get("location") and template.source == FileScope.GLOBAL):
-      test_file = global_dir / ".prich" / "templates" / template.id / f"{template.id}.yaml"
-      assert test_file.exists()
-      test_file.unlink()
+        test_file = global_dir / ".prich" / "templates" / template.id / f"{template.id}.yaml"
+        assert test_file.exists()
+        test_file.unlink()
 
 
 get_model_config_CASES = [
@@ -352,25 +408,25 @@ get_model_config_CASES = [
 ]
 @pytest.mark.parametrize("case", get_model_config_CASES, ids=[c["id"] for c in get_model_config_CASES])
 def test_model_config(tmp_path, monkeypatch, basic_config, case):
-  global_dir = tmp_path / "home"
-  local_dir = tmp_path / "local"
-  global_dir.mkdir()
-  local_dir.mkdir()
-  monkeypatch.setattr(Path, "home", lambda: global_dir)
-  monkeypatch.setattr(Path, "cwd", lambda: local_dir)
+    global_dir = tmp_path / "home"
+    local_dir = tmp_path / "local"
+    global_dir.mkdir()
+    local_dir.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: global_dir)
+    monkeypatch.setattr(Path, "cwd", lambda: local_dir)
 
-  if case.get("expected_exception") is not None:
-    with pytest.raises(case.get("expected_exception")) as e:
-      basic_config.save(case.get("location"))
+    if case.get("expected_exception") is not None:
+        with pytest.raises(case.get("expected_exception")) as e:
+            basic_config.save(case.get("location"))
     if case.get("expected_exception_text") is not None:
-      if case.get("expected_exception") == click.ClickException:
-        assert case.get("expected_exception_text") in e.value.message
-      else:
-        assert case.get("expected_exception_text") in str(e.value)
-  else:
-    basic_config.save(case.get("location"))
-    saved_into_dir = global_dir if case.get("location") == FileScope.GLOBAL else local_dir
-    assert (saved_into_dir / ".prich" / "config.yaml").exists()
-    basic_config.save(case.get("location"))
-    assert (saved_into_dir / ".prich" / "config.yaml").exists()
-    assert (saved_into_dir / ".prich" / "config.bak").exists()
+        if case.get("expected_exception") == click.ClickException:
+            assert case.get("expected_exception_text") in e.value.message
+        else:
+            assert case.get("expected_exception_text") in str(e.value)
+    else:
+        basic_config.save(case.get("location"))
+        saved_into_dir = global_dir if case.get("location") == FileScope.GLOBAL else local_dir
+        assert (saved_into_dir / ".prich" / "config.yaml").exists()
+        basic_config.save(case.get("location"))
+        assert (saved_into_dir / ".prich" / "config.yaml").exists()
+        assert (saved_into_dir / ".prich" / "config.bak").exists()

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,0 +1,67 @@
+import click
+import pytest
+
+from prich.models.config import STDINConsumerProviderModel
+
+from prich.llm_providers.stdin_consumer_provider import STDINConsumerProvider
+
+get_stdin_consumer_CASES = [
+    {"id": "stdin_consumer",
+     "name": "echo",
+     "prompt": {
+         "prompt": "test",
+     },
+     "provider": STDINConsumerProviderModel(
+         provider_type="stdin_consumer", name="echo", call="cat", args=[], mode="flat"
+     ),
+     "expected_output": "test",
+     },
+
+    {"id": "stdin_consumer_wrong_prompts",
+     "name": "echo",
+     "prompt": {
+         "system": "system",
+         "user": "user",
+     },
+     "provider": STDINConsumerProviderModel(
+         provider_type="stdin_consumer", name="echo", call="cat", args=[], mode="flat"
+     ),
+     "expected_exception": click.ClickException,
+     "expected_exception_messages": ["stdin consumer provider requires provider mode"],
+     },
+
+    {"id": "stdin_consumer_wrong_prompts",
+     "name": "echo",
+     "prompt": {
+         "prompt": "test",
+     },
+     "provider": STDINConsumerProviderModel(
+         provider_type="stdin_consumer", name="echo", call="catt", args=[], mode="flat"
+     ),
+     "expected_exception": click.ClickException,
+     "expected_exception_messages": ["STDIN consumer provider error: [Errno 2] No such file or director"],
+     },
+
+]
+@pytest.mark.parametrize("case", get_stdin_consumer_CASES, ids=[c["id"] for c in get_stdin_consumer_CASES])
+def test_stdin_consumer(case):
+    provider = case.get("provider")
+    stdin_consumer = STDINConsumerProvider(name=case.get("name"), provider=provider)
+
+    prompt = None
+    system = None
+    user = None
+    if case.get("prompt") is not None:
+        prompt = case["prompt"].get("prompt")
+        system = case["prompt"].get("system")
+        user = case["prompt"].get("user")
+    if case.get("expected_exception"):
+        with pytest.raises(case.get("expected_exception")) as e:
+            stdin_consumer.send_prompt(prompt=prompt, system=system, user=user)
+        if case.get("expected_exception_messages"):
+            for message in case.get("expected_exception_messages"):
+                assert message in str(e)
+    else:
+        result = stdin_consumer.send_prompt(prompt=prompt, system=system, user=user)
+        if case.get("expected_output"):
+            assert case.get("expected_output") == result

--- a/tests/test_run_template.py
+++ b/tests/test_run_template.py
@@ -7,7 +7,7 @@ from prich.cli.config import list_providers, show_config, edit_config
 from prich.core.engine import run_template
 from prich.core.state import _loaded_templates
 from prich.models.template import TemplateModel, PromptFields, VariableDefinition, PythonStep, CommandStep, LLMStep, \
-    RenderStep
+    RenderStep, ValidateStepOutput
 from tests.fixtures.config import basic_config
 from tests.fixtures.paths import mock_paths
 from tests.fixtures.templates import template
@@ -15,10 +15,11 @@ from tests.fixtures.templates import template
 
 get_run_template_CASES = [
     {"id": "valid_one_llm_step", "template":
-        TemplateModel(
-            id="test-tpl",
-            name="Test TPL",
-            steps=[
+        # TemplateModel(
+        {
+            "id": "test-tpl",
+            "name": "Test TPL",
+            "steps":[
                 LLMStep(
                     name="Ask",
                     type="llm",
@@ -28,15 +29,17 @@ get_run_template_CASES = [
                     )
                 )
             ]
-        ),
+        # ),
+        },
       "expected_exception": None,
       "expected_exception_message": None,
     },
     {"id": "valid_llm_step_and_python_cmd_and_render", "template":
-        TemplateModel(
-            id="test-tpl",
-            name="Test TPL",
-            steps=[
+        # TemplateModel(
+        {
+            "id": "test-tpl",
+            "name": "Test TPL",
+            "steps": [
                 PythonStep(
                     name="Preprocess python",
                     type="python",
@@ -66,19 +69,22 @@ get_run_template_CASES = [
                     prompt=PromptFields(
                         system="system",
                         user="user"
-                    )
+                    ),
+                    output_file="test_llm_response.txt"
                 ),
             ],
-            folder="."
-        ),
+            "folder": "."
+        # ),
+        },
       "expected_exception": None,
       "expected_exception_message": None,
     },
     {"id": "no_template_folder_set", "template":
-        TemplateModel(
-            id="test-tpl",
-            name="Test TPL",
-            steps=[
+        # TemplateModel(
+        {
+            "id": "test-tpl",
+            "name": "Test TPL",
+            "steps": [
                 CommandStep(
                     name="Preprocess command",
                     type="command",
@@ -86,15 +92,17 @@ get_run_template_CASES = [
                     args=["test"]
                 ),
             ],
-        ),
+        # ),
+        },
       "expected_exception": click.ClickException,
       "expected_exception_message": "Template folder was not detected properly",
     },
     {"id": "no_python_script_found", "template":
-        TemplateModel(
-            id="test-tpl",
-            name="Test TPL",
-            steps=[
+        # TemplateModel(
+        {
+            "id": "test-tpl",
+            "name": "Test TPL",
+            "steps": [
                 PythonStep(
                     name="Preprocess python",
                     type="python",
@@ -102,16 +110,18 @@ get_run_template_CASES = [
                     args=["test"]
                 ),
             ],
-            folder="."
-        ),
+            "folder": "."
+        # ),
+        },
       "expected_exception": click.ClickException,
       "expected_exception_message": "Python script not found",
     },
     {"id": "non_python_script_found", "template":
-        TemplateModel(
-            id="test-tpl",
-            name="Test TPL",
-            steps=[
+        # TemplateModel(
+        {
+            "id": "test-tpl",
+            "name": "Test TPL",
+            "steps": [
                 PythonStep(
                     name="Preprocess python",
                     type="python",
@@ -119,16 +129,18 @@ get_run_template_CASES = [
                     args=["test"]
                 ),
             ],
-            folder="."
-        ),
+            "folder": "."
+        # ),
+        },
       "expected_exception": click.ClickException,
       "expected_exception_message": "Python script file should end with .py",
     },
     {"id": "cmd_exec_error", "template":
-        TemplateModel(
-            id="test-tpl",
-            name="Test TPL",
-            steps=[
+        # TemplateModel(
+        {
+            "id": "test-tpl",
+            "name": "Test TPL",
+            "steps": [
                 CommandStep(
                     name="Preprocess command",
                     type="command",
@@ -136,16 +148,18 @@ get_run_template_CASES = [
                     args=["test"]
                 ),
             ],
-            folder="."
-        ),
+            "folder": "."
+        # ),
+        },
       "expected_exception": click.ClickException,
       "expected_exception_message": "Execution error in ",
     },
     {"id": "no_cmd_found", "template":
-        TemplateModel(
-            id="test-tpl",
-            name="Test TPL",
-            steps=[
+        # TemplateModel(
+        {
+            "id": "test-tpl",
+            "name": "Test TPL",
+            "steps": [
                 CommandStep(
                     name="Preprocess command",
                     type="command",
@@ -153,17 +167,19 @@ get_run_template_CASES = [
                     args=["test"]
                 ),
             ],
-            folder="."
-        ),
+            "folder": "."
+        # ),
+        },
       "expected_exception": click.ClickException,
       "expected_exception_message": "No such file or directory",
     },
     {"id": "no_python_isolated_venv_found", "template":
-        TemplateModel(
-            id="test-tpl",
-            name="Test TPL",
-            venv="isolated",
-            steps=[
+        # TemplateModel(
+        {
+            "id": "test-tpl",
+            "name": "Test TPL",
+            "venv": "isolated",
+            "steps": [
                 PythonStep(
                     name="Preprocess python",
                     type="python",
@@ -171,16 +187,18 @@ get_run_template_CASES = [
                     args=["test"]
                 ),
             ],
-            folder="."
-        ),
+            "folder": "."
+        # ),
+        },
       "expected_exception": click.ClickException,
       "expected_exception_message": "Isolated venv python not found",
     },
     {"id": "valid_one_llm_step_w_vars", "template":
-        TemplateModel(
-            id="test-tpl",
-            name="Test TPL",
-            steps=[
+        # TemplateModel(
+        {
+            "id": "test-tpl",
+            "name": "Test TPL",
+            "steps": [
                 LLMStep(
                     name="Ask",
                     type="llm",
@@ -190,7 +208,7 @@ get_run_template_CASES = [
                     )
                 )
             ],
-            variables=[
+            "variables": [
                 VariableDefinition(
                     name="test_var1",
                     type="str",
@@ -228,23 +246,268 @@ get_run_template_CASES = [
                     default=[1, 2],
                 ),
             ]
-        ),
+        # ),
+        },
       "expected_exception": None,
       "expected_exception_message": None,
     },
     {"id": "no_steps", "template":
-        TemplateModel(
-            id="test-tpl",
-            name="Test TPL",
-            steps=[]
-        ),
+        # TemplateModel(
+        {
+            "id": "test-tpl",
+            "name": "Test TPL",
+            "steps": []
+        # ),
+        },
       "expected_exception": click.ClickException,
       "expected_exception_message": "No steps found in template test-tpl.",
+     },
+    {"id": "run_cmd_and_validate_error", "template":
+        # TemplateModel(
+        {
+            "id": "test-tpl",
+            "name": "Test TPL",
+            "steps": [
+                PythonStep(
+                    name="Preprocess python",
+                    type="python",
+                    call="echo.py",
+                    args=["test"],
+                    validate=ValidateStepOutput(
+                        match="^est",
+                        not_match="test",
+                        on_fail="error"
+                    )
+                ),
+            ],
+            "folder": "."
+        # ),
+        },
+     "expected_exception": click.ClickException,
+     "expected_exception_message": "Validation failed for step output",
+     },
+    {"id": "run_cmd_and_validate_warn", "template":
+        # TemplateModel(
+        {
+            "id": "test-tpl",
+            "name": "Test TPL",
+            "steps": [
+                PythonStep(
+                    name="Preprocess python",
+                    type="python",
+                    call="echo.py",
+                    args=["test"],
+                    validate=ValidateStepOutput(
+                        match="^est",
+                        not_match="test",
+                        on_fail="warn"
+                    )
+                ),
+            ],
+            "folder": "."
+        # ),
+        },
+     },
+    {"id": "run_cmd_and_validate_skip", "template":
+        # TemplateModel(
+        {
+            "id": "test-tpl",
+            "name": "Test TPL",
+            "steps": [
+                PythonStep(
+                    name="Preprocess python",
+                    type="python",
+                    call="echo.py",
+                    args=["test"],
+                    validate=ValidateStepOutput(
+                        match="^est",
+                        not_match="test",
+                        on_fail="skip"
+                    )
+                ),
+            ],
+            "folder": "."
+        # ),
+        },
+     },
+    {"id": "run_cmd_and_validate_continue", "template":
+        # TemplateModel(
+        {
+            "id": "test-tpl",
+            "name": "Test TPL",
+            "steps": [
+                PythonStep(
+                    name="Preprocess python",
+                    type="python",
+                    call="echo.py",
+                    args=["test"],
+                    validate=ValidateStepOutput(
+                        match="^est",
+                        not_match="test",
+                        on_fail="continue"
+                    )
+                ),
+            ],
+            "folder": "."
+        # ),
+        },
+     },
+    {"id": "run_cmd_and_validate_passed", "template":
+        # TemplateModel(
+        {
+            "id": "test-tpl",
+            "name": "Test TPL",
+            "steps": [
+                PythonStep(
+                    name="Preprocess python",
+                    type="python",
+                    call="echo.py",
+                    args=["test"],
+                    validate=ValidateStepOutput(
+                        match="^test",
+                        not_match="echo",
+                        on_fail="error"
+                    )
+                ),
+            ],
+            "folder": "."
+        # ),
+        },
+     },
+    {"id": "run_cmd_and_strip_prefix", "template":
+        # TemplateModel(
+        {
+            "id": "test-tpl",
+            "name": "Test TPL",
+            "steps": [
+                PythonStep(
+                    name="Preprocess python",
+                    type="python",
+                    call="echo.py",
+                    args=["test"],
+                    strip_output_prefix="te",
+                    validate=ValidateStepOutput(
+                        match="^st",
+                        not_match="echo",
+                        on_fail="error"
+                    )
+                ),
+            ],
+            "folder": "."
+        # ),
+        },
+     },
+    {"id": "run_cmd_and_slice", "template":
+        # TemplateModel(
+        {
+            "id": "test-tpl",
+            "name": "Test TPL",
+            "steps": [
+                PythonStep(
+                    name="Preprocess python",
+                    type="python",
+                    call="echo.py",
+                    args=["test"],
+                    slice_output_start=1,
+                    slice_output_end=-1,
+                    validate=ValidateStepOutput(
+                        match="^es$",
+                        not_match="echo",
+                        on_fail="error"
+                    )
+                ),
+            ],
+            "folder": "."
+        # ),
+        },
+     },
+    {"id": "run_cmd_and_slice_start", "template":
+        # TemplateModel(
+        {
+            "id": "test-tpl",
+            "name": "Test TPL",
+            "steps": [
+                PythonStep(
+                    name="Preprocess python",
+                    type="python",
+                    call="echo.py",
+                    args=["test"],
+                    slice_output_start=1,
+                    validate=ValidateStepOutput(
+                        match="^est$",
+                        not_match="echo",
+                        on_fail="error"
+                    )
+                ),
+            ],
+            "folder": "."
+        # ),
+        },
+     },
+    {"id": "run_cmd_and_slice_end", "template":
+        # TemplateModel(
+        {
+            "id": "test-tpl",
+            "name": "Test TPL",
+            "steps": [
+                PythonStep(
+                    name="Preprocess python",
+                    type="python",
+                    call="echo.py",
+                    args=["test"],
+                    slice_output_end=-1,
+                    validate=ValidateStepOutput(
+                        match="^tes$",
+                        not_match="echo",
+                        on_fail="error"
+                    )
+                ),
+            ],
+            "folder": "."
+        # ),
+        },
+     },
+    {"id": "run_cmd_and_save_output", "template":
+        # TemplateModel(
+        {
+            "id": "test-tpl",
+            "name": "Test TPL",
+            "steps": [
+                PythonStep(
+                    name="Preprocess python",
+                    type="python",
+                    call="echo.py",
+                    args=["test"],
+                    output_variable="test_var",
+                    output_file="haudfhiu!@#±%#@$^%^(*0=/////"
+                ),
+            ],
+            "folder": "."
+        # ),
+        },
+     "expected_exception": click.ClickException,
+     "expected_exception_message": "Failed to save output to file",
      },
 ]
 @pytest.mark.parametrize("case", get_run_template_CASES, ids=[c["id"] for c in get_run_template_CASES])
 def test_run_template(case, monkeypatch, basic_config):
-    test_template = case.get("template")
+    test_template = TemplateModel(
+            id= "test-tpl",
+            name= "Test TPL",
+            steps= [
+                PythonStep(
+                    name="Preprocess python",
+                    type="python",
+                    call="echo.py",
+                    args=["test"],
+                    output_variable="test_var"
+                ),
+            ],
+        )
+        # },
+
+    for k,v in case.get("template").items():
+        test_template.__setattr__(k, v)
     if test_template.folder == ".":
         test_template.folder = str(Path(__file__).parent.resolve())
     _loaded_templates.clear()

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,0 +1,254 @@
+import pytest
+from click.testing import CliRunner
+from prich.models.file_scope import FileScope
+
+from prich.cli.templates import venv_install, show_template
+from prich.core.state import _loaded_templates
+
+from tests.fixtures.paths import mock_paths
+from tests.fixtures.templates import template
+
+get_venv_install_CASES = [
+    {"id": "install_local_venv_no_params",
+     "args": [],
+     "expected_exit_code": 2,
+     "expected_exception_message": "Usage: venv-install",
+    },
+    {"id": "install_local_venv_when_no_venv_in_template",
+     "args": ["template-local"],
+     "expected_exit_code": 0,
+     "expected_exception_message": "Template template-local doesn\'t require venv",
+    },
+    {"id": "install_global_venv_when_no_venv_in_template",
+     "args": ["template-global"],
+     "expected_exit_code": 0,
+     "expected_exception_message": "Template template-global doesn\'t require venv",
+    },
+    {"id": "install_local_isolated_venv",
+     "args": ["template-local"],
+     "venv": "isolated",
+     "expected_exit_code": 0,
+     "expected_exception_message": "Installing isolated venv... done",
+    },
+    {"id": "install_global_isolated_venv",
+     "args": ["template-global"],
+     "venv": "isolated",
+     "expected_exit_code": 0,
+     "expected_exception_message": "Installing isolated venv... done",
+    },
+    {"id": "install_local_shared_venv",
+     "args": ["template-local"],
+     "venv": "shared",
+     "expected_exit_code": 0,
+     "expected_exception_message": "Installing shared venv... done",
+    },
+    {"id": "install_global_shared_venv",
+     "args": ["template-global"],
+     "venv": "shared",
+     "expected_exit_code": 0,
+     "expected_exception_message": "Installing shared venv... done",
+    },
+    {"id": "install_local_isolated_venv_again_and_force",
+     "venv": "isolated",
+     "multiple": [
+         { "args": ["template-local"],
+           "expected_exit_code": 0,
+           "expected_exception_message": "Installing isolated venv... done",
+           },
+         { "args": ["template-local"],
+           "expected_exit_code": 0,
+           "expected_exception_message": "Venv folder found. No dependencies to install. Done!",
+           },
+         { "args": ["template-local", "--force"],
+           "expected_exit_code": 0,
+           "expected_exception_message": "Installing isolated venv... done",
+           }
+     ],
+     },
+    {"id": "install_global_isolated_venv_again_and_force",
+     "venv": "isolated",
+     "multiple": [
+         { "args": ["template-global"],
+           "expected_exit_code": 0,
+           "expected_exception_message": "Installing isolated venv... done",
+           },
+         { "args": ["template-global"],
+           "expected_exit_code": 0,
+           "expected_exception_message": "Venv folder found. No dependencies to install. Done!",
+           },
+         { "args": ["template-global", "--force"],
+           "expected_exit_code": 0,
+           "expected_exception_message": "Installing isolated venv... done",
+           }
+     ],
+     },
+    {"id": "install_local_shared_venv_again_and_force",
+     "venv": "shared",
+     "multiple": [
+         {"args": ["template-local"],
+          "expected_exit_code": 0,
+          "expected_exception_message": "Installing shared venv... done! No dependencies to install. Done!",
+          },
+         {"args": ["template-local"],
+          "expected_exit_code": 0,
+          "expected_exception_message": "Venv folder found. No dependencies to install. Done!",
+          },
+         {"args": ["template-local", "--force"],
+          "expected_exit_code": 1,
+          "expected_exception_message": "Shared venv with --force is not supported as it might break",
+          }
+     ]
+    },
+    {"id": "install_global_shared_venv_again_and_force",
+     "venv": "shared",
+     "multiple": [
+         {"args": ["template-global"],
+          "expected_exit_code": 0,
+          "expected_exception_message": "Installing shared venv... done! No dependencies to install. Done!",
+          },
+         {"args": ["template-global"],
+          "expected_exit_code": 0,
+          "expected_exception_message": "Venv folder found. No dependencies to install. Done!",
+          },
+         {"args": ["template-global", "--force"],
+          "expected_exit_code": 1,
+          "expected_exception_message": "Shared venv with --force is not supported as it might break",
+          }
+     ]
+    },
+]
+@pytest.mark.parametrize("case", get_venv_install_CASES, ids=[c["id"] for c in get_venv_install_CASES])
+def test_venv_install(mock_paths, template, case):
+    from pathlib import Path
+    template_local = template.model_copy(deep=True)
+    template_global = template.model_copy(deep=True)
+    template_local.id = "template-local"
+    template_global.id = "template-global"
+    template_local.folder = str(mock_paths.prich.local_templates / template_local.id)
+    template_global.folder = str(mock_paths.prich.global_templates / template_global.id)
+    template_local.file = str(Path(template_local.folder) / f"{template_local.id}.yaml")
+    template_global.file = str(Path(template_global.folder) / f"{template_global.id}.yaml")
+    template_local.description = case.get("id")
+    template_global.description = case.get("id")
+    if case.get("venv") is not None:
+        template_local.venv = case.get("venv")
+        template_global.venv = case.get("venv")
+    template_local.save(FileScope.LOCAL)
+    template_global.save(FileScope.GLOBAL)
+
+    if case.get("multiple"):
+        inputs = case.get("multiple")
+    else:
+        inputs = [
+            {"args": case.get("args"),
+             "expected_exit_code": case.get("expected_exit_code"),
+             "expected_exception_message": case.get("expected_exception_message"),
+             },
+        ]
+    runner = CliRunner()
+    iteration_idx = 0
+    with runner.isolated_filesystem():
+        iteration_idx += 1
+        for case_input in inputs:
+            result = runner.invoke(venv_install, case_input.get("args"))
+            if case_input.get("expected_exception_message") is not None:
+                assert case_input.get("expected_exception_message") in result.output.replace("\n", " "), f"Iteration {iteration_idx}"
+            if case_input.get("expected_exit_code") is not None:
+                assert result.exit_code == case_input.get("expected_exit_code"), f"Iteration {iteration_idx}"
+
+get_show_template_CASES = [
+    {"id": "show_no_tempate_id",
+     "args": [],
+     "expected_exit_code": 2,
+     "expected_exception_message": "Usage: show",
+     },
+    {"id": "show_template_id",
+     "args": ["template-local"],
+     "expected_exit_code": 0,
+     "expected_exception_message": "Template: id: template-local",
+     },
+    {"id": "show_template_id_local_with_g",
+     "args": ["template-local", "--global"],
+     "expected_exit_code": 1,
+     "expected_exception_message": "Error: Template template-local not found.",
+     },
+    {"id": "show_template_id_global",
+     "args": ["template-global"],
+     "expected_exit_code": 0,
+     "expected_exception_message": "Template: id: template-global",
+     },
+
+]
+@pytest.mark.parametrize("case", get_show_template_CASES, ids=[c["id"] for c in get_show_template_CASES])
+def test_show_template(mock_paths, template, case):
+    from pathlib import Path
+    if case.get("args") is not []:
+        template_local = template.model_copy(deep=True)
+        template_global = template.model_copy(deep=True)
+        template_local.id = "template-local"
+        template_global.id = "template-global"
+        template_local.folder = str(mock_paths.prich.local_templates / template_local.id)
+        template_global.folder = str(mock_paths.prich.global_templates / template_global.id)
+        template_local.file = str(Path(template_local.folder) / f"{template_local.id}.yaml")
+        template_global.file = str(Path(template_global.folder) / f"{template_global.id}.yaml")
+        template_local.description = case.get("id")
+        template_global.description = case.get("id")
+        template_local.save(FileScope.LOCAL)
+        template_global.save(FileScope.GLOBAL)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(show_template, case.get("args"))
+        if case.get("expected_exception_message") is not None:
+            assert case.get("expected_exception_message") in result.output.replace("\n", " ")
+        if case.get("expected_exit_code") is not None:
+            assert result.exit_code == case.get("expected_exit_code")
+
+get_create_template_CASES = [
+    {"id": "create_template_no_template_id",
+     "iterations": [
+         {"args": [],
+          "expected_exception_messages": ["Usage: create [OPTIONS] TEMPLATE_ID"],
+          "expected_exit_code": 2},
+     ]
+     },
+    {"id": "create_template_local",
+     "iterations": [
+         {"args": ["test-tpl"],
+          "expected_exception_messages": ["Template test-tpl created in", "local/.prich/templates/test-tpl/test-tpl"],
+          "expected_exit_code": 0,
+          "check_file": ""},
+         {"args": ["test-tpl"],
+          "expected_exception_messages": ["Error: Template test-tpl already exists."],
+          "expected_exit_code": 1,
+          "check_file": ""},
+     ]
+     },
+    {"id": "create_template_global",
+     "iterations": [
+         {"args": ["test-tpl", "-g"],
+          "expected_exception_message": ["Template test-tpl created in", "global/.prich/templates/test-tpl/test-tpl"],
+          "expected_exit_code": 0,
+          "check_file": ""},
+         {"args": ["test-tpl", "-g"],
+          "expected_exception_message": ["Error: Template test-tpl already exists."],
+          "expected_exit_code": 1,
+          "check_file": ""},
+     ]
+     },
+]
+@pytest.mark.parametrize("case", get_create_template_CASES, ids=[c["id"] for c in get_create_template_CASES])
+def test_create_template(mock_paths, case):
+    from prich.cli.templates import create_template
+    _loaded_templates.clear()
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        for iteration in case.get("iterations"):
+            result = runner.invoke(create_template, iteration.get("args"))
+            if iteration.get("expected_exception_messages") is not None:
+                for message in iteration.get("expected_exception_messages"):
+                    assert message in result.output.replace("\n", " ")
+            if iteration.get("expected_exit_code") is not None:
+                assert result.exit_code == iteration.get("expected_exit_code")
+
+

--- a/tests/test_template_install.py
+++ b/tests/test_template_install.py
@@ -1,23 +1,163 @@
-import tempfile
-from pathlib import Path
 import pytest
 from click.testing import CliRunner
 from prich.cli.templates import template_install
-from prich.core.loaders import load_config_model, load_template_model
-from prich.core.engine import render_prompt
-from prich.models.template import PromptFields
-from tests.fixtures.config import CONFIG_YAML
 from tests.fixtures.paths import mock_paths
-from tests.fixtures.templates import temp_template_dir, INVALID_TEMPLATE_YAML
+from tests.fixtures.templates import temp_template_dir
 
-
-def test_template_install_local(temp_template_dir, mock_paths):
+get_template_install_CASES = [
+    {"id": "template_install_local",
+     "from": "path",
+     "iterations": [
+         {"additional_args": [],
+         "expected_exit_code": 0,
+         "expected_messages": ["Template test_template installed successfully", "./.prich"]
+         },
+         {"additional_args": [],
+         "expected_exit_code": 1,
+         "expected_messages": ["Error: Template 'test_template' already exists in local directory", "./.prich"]
+         },
+         {"additional_args": ["--force"],
+         "expected_exit_code": 0,
+         "expected_messages": ["Template test_template installed successfully", "./.prich"]
+         },
+    ]},
+    {"id": "template_install_global",
+     "from": "path",
+     "iterations": [
+         {"additional_args": ["-g"],
+         "expected_exit_code": 0,
+         "expected_messages": ["Template test_template installed successfully", "~/.prich"]
+         },
+         {"additional_args": ["-g"],
+         "expected_exit_code": 1,
+         "expected_messages": ["Error: Template 'test_template' already exists in global directory", "~/.prich"]
+         },
+         {"additional_args": ["-g", "--force"],
+         "expected_exit_code": 0,
+         "expected_messages": ["Template test_template installed successfully", "~/.prich"]
+         },
+     ]},
+    {"id": "template_install_local_from_remote",
+     "iterations": [
+         {"additional_args": ["code-review", "-r"],
+          "expected_exit_code": 0,
+          "expected_messages": ["Template code-review installed successfully", "./.prich"]
+          },
+         {"additional_args": ["code-review", "-r"],
+         "expected_exit_code": 1,
+         "expected_messages": ["Error: Template 'code-review' already exists in local directory", "./.prich"]
+         },
+         {"additional_args": ["code-review", "-r", "--force"],
+         "expected_exit_code": 0,
+         "expected_messages": ["Template code-review installed successfully", "./.prich"]
+         },
+         ]
+     },
+    {"id": "template_install_global_from_remote",
+     "iterations": [
+         {"additional_args": ["code-review", "-r", "-g"],
+         "expected_exit_code": 0,
+         "expected_messages": ["Template code-review installed successfully", "~/.prich"]
+         },
+         {"additional_args": ["code-review", "-r", "-g"],
+         "expected_exit_code": 1,
+         "expected_messages": ["Error: Template 'code-review' already exists in global directory", "~/.prich"]
+         },
+         {"additional_args": ["code-review", "-r", "-g", "--force"],
+         "expected_exit_code": 0,
+         "expected_messages": ["Template code-review installed successfully", "~/.prich"]
+         },
+         ]
+     },
+    {"id": "template_install_local_not_existing_from_remote",
+     "iterations": [
+         {"additional_args": ["not-existing-template", "-r"],
+         "expected_exit_code": 1,
+         "expected_messages": [
+             "Error: Remote Template ID not-existing-template not found in the repository"
+         ]},
+     ]
+     },
+    {"id": "template_install_global_not_existing_from_remote",
+     "iterations": [
+         {"additional_args": ["not-existing-template", "-r", "-g"],
+          "expected_exit_code": 1,
+          "expected_messages": [
+              "Error: Remote Template ID not-existing-template not found in the repository"
+          ]},
+     ]
+     },
+    {"id": "template_install_from_folder_no_yaml",
+     "from": "path",
+     "no_yaml_file": True,
+     "iterations": [
+         {"additional_args": [],
+          "expected_exit_code": 1,
+          "expected_messages": ["Error: No template YAML found"]
+          },
+     ]},
+    {"id": "template_install_from_folder_empty_yaml",
+     "from": "path",
+     "empty_yaml_file": True,
+     "iterations": [
+         {"additional_args": [],
+          "expected_exit_code": 1,
+          "expected_messages": ["Error: Failed to load template:", " is empty"]
+          },
+     ]},
+    {"id": "template_install_from_folder_empty_yaml_chmod_yes",
+     "from": "path",
+     "add_scripts_to_folder": True,
+     "simulate_input": "yes",
+     "iterations": [
+         {"additional_args": [],
+          "expected_exit_code": 0,
+          "expected_messages": ["Installing template to ", "Setup Scripts:", "+ ./scripts/test.py", "+ ./scripts/test.sh", "Running chmod", "Done!", "Template test_template installed successfully."]
+          },
+     ]},
+    {"id": "template_install_from_folder_empty_yaml_chmod_no",
+     "from": "path",
+     "add_scripts_to_folder": True,
+     "simulate_input": "no",
+     "iterations": [
+         {"additional_args": [],
+          "expected_exit_code": 0,
+          "expected_messages": ["Installing template to ", "Setup Scripts:", "+ ./scripts/test.py", "+ ./scripts/test.sh", "Skipped chmod 755.", "Done!", "Template test_template installed successfully."]
+          },
+     ]},
+]
+@pytest.mark.parametrize("case", get_template_install_CASES, ids=[c["id"] for c in get_template_install_CASES])
+def test_template_install_from_folder(case, temp_template_dir, mock_paths, monkeypatch):
+    from prich.core.state import _loaded_templates
+    _loaded_templates = []
     runner = CliRunner()
+    if case.get("no_yaml_file"):
+        (temp_template_dir / "test_template.yaml").unlink()
+    if case.get("empty_yaml_file"):
+        (temp_template_dir / "test_template.yaml").write_text("")
+    if case.get("simulate_input"):
+        monkeypatch.setattr('builtins.input', lambda _: case.get("simulate_input"))
+    if case.get("add_scripts_to_folder"):
+        scripts_folder = temp_template_dir / "scripts"
+        scripts_folder.mkdir(exist_ok=True)
+        (scripts_folder / "test.sh").write_text("#!/bin/bash\necho \"test\"")
+        (scripts_folder / "test.py").write_text("print(\"test\")")
+        (scripts_folder / "requirements.txt").write_text("httpx==0.28.1")
     with runner.isolated_filesystem():
-        result = runner.invoke(template_install, [str(temp_template_dir)])
-        assert result.exit_code == 0
-        assert "Template test_template installed successfully" in result.output
-        assert Path(mock_paths.prich.local_templates / "test_template" / "test_template.yaml").exists()
+        for iteration in case.get("iterations"):
+            if case.get("from") == "path":
+                args = [str(temp_template_dir)]
+            else:
+                args = []
+            args.extend(iteration.get("additional_args"))
+            result = runner.invoke(template_install, args)
+            if iteration.get("expected_messages") is not None:
+                for message in iteration.get("expected_messages"):
+                    assert message in result.output
+            if iteration.get("expected_exit_code") is not None:
+                assert result.exit_code == iteration.get("expected_exit_code")
+
+            # assert Path(mock_paths.prich.local_templates / "test_template" / "test_template.yaml").exists()
 
 
 def test_template_install_force_overwrite(temp_template_dir, mock_paths):

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,29 +1,65 @@
 from pathlib import Path
 import pytest
 from click.testing import CliRunner
+from prich.models.file_scope import FileScope
+
+from prich.cli.validate import validate_templates
+from tests.fixtures.templates import template
 
 get_validate_template_CASES = [
-    {"id": "local_and_global_params", "args": ["-g", "-l"], "expected_output": "Error: Use only one local or global option"},
-    {"id": "file_with_local_param", "args": ["--file", "test.yaml", "-l"], "expected_output": "When YAML file is selected it doesn't combine with local, global, or id options"},
-    {"id": "file_with_global_param", "args": ["--file", "test.yaml", "-g"], "expected_output": "When YAML file is selected it doesn't combine with local, global, or id options"},
-    {"id": "file_with_template_id_param", "args": ["--file", "test.yaml", "--id", "test-template"], "expected_output": "When YAML file is selected it doesn't combine with local, global, or id options"},
-    {"id": "file_not_present", "args": ["--file", "test.yaml"], "expected_output": "Failed to find test.yaml template file."},
-    {"id": "no_templates_found", "args": [], "expected_output": "No Templates found."},
-    {"id": "no_template_if_found", "args": ["--id", "test-template"], "expected_output": " Failed to find template with id: test-template"},
+    {"id": "local_and_global_params", "args": ["-g", "-l"],
+     "expected_output": "Error: Use only one local or global option"},
+    {"id": "file_with_local_param", "args": ["--file", "test.yaml", "-l"],
+     "expected_output": "When YAML file is selected it doesn't combine with local, global, or id options"},
+    {"id": "file_with_global_param", "args": ["--file", "test.yaml", "-g"],
+     "expected_output": "When YAML file is selected it doesn't combine with local, global, or id options"},
+    {"id": "file_with_template_id_param", "args": ["--file", "test.yaml", "--id", "test-template"],
+     "expected_output": "When YAML file is selected it doesn't combine with local, global, or id options"},
+    {"id": "file_not_present", "args": ["--file", "test.yaml"],
+     "expected_output": "Failed to find test.yaml template file."},
+    {"id": "no_templates_found", "args": [],
+     "expected_output": "No Templates found."},
+    {"id": "no_template_if_found", "args": ["--id", "test-template"],
+     "expected_output": "Failed to find template with id: test-template"},
+    {"id": "local_template_id", "add_template": True, "args": ["--id", "template-local"],
+     "expected_output": "- template-local (local)"},
+    {"id": "local_template_id_w_local", "add_template": True, "args": ["--id", "template-local", "-l"],
+     "expected_output": "- template-local (local)"},
+    {"id": "local_template_id_w_global_not_found", "add_template": True, "args": ["--id", "template-local", "-g"],
+     "expected_output": "Failed to find template with id: template-local"},
+    {"id": "global_template_id", "add_template": True, "args": ["--id", "template-global"],
+     "expected_output": "- template-global (global)"},
+    {"id": "global_template_id_w_local_not_found", "add_template": True, "args": ["--id", "template-global", "-l"],
+     "expected_output": "Failed to find template with id: template-global"},
+    {"id": "local_template_wrong", "add_wrong_template": True, "args": [],
+     "expected_output": "tpl-local-wrong.yaml: is not valid"},
 ]
 @pytest.mark.parametrize("case", get_validate_template_CASES, ids=[c["id"] for c in get_validate_template_CASES])
-def test_validate_template(tmp_path, monkeypatch, case):
-    from prich.cli.validate import validate_templates
-
+def test_validate_template(tmp_path, monkeypatch, case, template):
     global_dir = tmp_path / "home"
     local_dir = tmp_path / "local"
     global_dir.mkdir()
     local_dir.mkdir()
+
     monkeypatch.setattr(Path, "home", lambda: global_dir)
     monkeypatch.setattr(Path, "cwd", lambda: local_dir)
+
+    if case.get("add_template"):
+        template_local = template.model_copy(deep=True)
+        template_global = template.model_copy(deep=True)
+        template_local.id = "template-local"
+        template_global.id = "template-global"
+        template_local.save(FileScope.LOCAL)
+        template_global.save(FileScope.GLOBAL)
+
+    if case.get("add_wrong_template"):
+        template_local_wrong = template.model_copy(deep=True)
+        template_local_wrong.id = "tpl-local-wrong"
+        template_local_wrong.steps = []
+        template_local_wrong.save(FileScope.LOCAL)
 
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=tmp_path):
         result = runner.invoke(validate_templates, case.get("args"))
         if case.get("expected_output") is not None:
-            assert case.get("expected_output") in result.output
+            assert case.get("expected_output") in result.output.replace("\n", " ")


### PR DESCRIPTION
The refactored code introduces **parameterized test cases** using `pytest.mark.parametrize`, with each test case stored in a list (e.g., `get_list_template_CASES`, `get_show_template_CASES`, `get_validate_template_CASES`)

- **CLI Command Invocation**
Each test case now builds the CLI command arguments dynamically based on the case parameters.
  - **Invalid YAML files**: Ensuring the CLI correctly reports missing files.
  - **Conflicting flags**: For example, using both `-l` and `-g` together, which should trigger an error.
  - **Empty or malformed templates**: Validating that the CLI detects invalid templates (e.g., empty YAML files).

- The refactored tests include several new scenarios:
  - **Checking specific templates**: For example, verifying the output for a template with ID `template-local` or `template-global`.
  - **Validation errors**: Testing cases where invalid templates (e.g., missing steps) are flagged.
  - **Global vs. Local Templates**: Ensuring the CLI correctly distinguishes between templates saved in the global and local directories.

- The tests now interact with a mock template system (via `template` fixtures and `FileScope` enums), ensuring the CLI correctly loads and validates templates from specified directories (e.g., `local_templates`, `global_templates`). This integration ensures the CLI behaves as expected when templates are present or missing.

