### PR TITLE
add output_regex and extract_vars to steps

### DIFF
--- a/prich/core/engine.py
+++ b/prich/core/engine.py
@@ -402,13 +402,20 @@ def run_template(template_id, **kwargs):
             else:
                 raise click.ClickException(f"Step {step.type} type is not supported.")
 
-            if step.strip_output_prefix or step.slice_output_start or step.slice_output_end:
-                if is_verbose():
-                    if step.strip_output_prefix:
-                        console_print(f"[dim]Strip output prefix: {step.strip_output_prefix}[/dim]")
-                    if step.slice_output_start or step.slice_output_end:
-                        console_print(f"[dim]Slice output text{f' from {step.slice_output_start}' if step.slice_output_start else ''}{f' to {step.slice_output_end}' if step.slice_output_end else ''}[/dim]")
-                step_output = step.strip_and_slice_output(step_output)
+            if is_verbose():
+                if step.extract_vars or step.output_regex or step.strip_output_prefix or step.slice_output_start or step.slice_output_end:
+                    console_print(f"[dim]Output: '{step_output}'[/dim]")
+            step_output = step.postprocess_output(output=step_output, variables=variables)
+            if is_verbose():
+                if step.extract_vars:
+                    for spec in step.extract_vars:
+                        console_print(f"[dim]Inject \"{spec.regex}\" {f'({len(variables.get(spec.variable))} matches) ' if spec.multiple else ''}→ {spec.variable}: {f'{variables.get(spec.variable)}' if type(variables.get(spec.variable) == str) else variables.get(spec.variable)}[/dim]")
+                if step.output_regex:
+                    console_print(f"[dim]Apply regex: \"{step.output_regex}\"[/dim]")
+                if step.strip_output_prefix:
+                    console_print(f"[dim]Strip output prefix: \"{step.strip_output_prefix}\"[/dim]")
+                if step.slice_output_start or step.slice_output_end:
+                    console_print(f"[dim]Slice output text{f' from {step.slice_output_start}' if step.slice_output_start else ''}{f' to {step.slice_output_end}' if step.slice_output_end else ''}[/dim]")
 
             # Store last output
             last_output = step_output


### PR DESCRIPTION
The diff introduces significant improvements to the output processing logic in `prich/core/engine.py` and `prich/models/template.py`. Key changes include:
1. **Enhanced Postprocessing Logic**:  
   - Replaced the simple `strip_and_slice_output` method with a more comprehensive `postprocess_output` method that supports:
     - Regex-based variable extraction (`extract_vars`).
     - Regex transformations on the main output (`output_regex`).
     - Stripping prefixes and slicing output.
2. **Detailed Logging**:  
   - Expanded verbose output to include:
     - Regex patterns and variable injection details.
     - Output regex application.
     - Strip/slice operations.
3. **New Data Models**:  
   - Added `ExtractVarModel` to define regex-based variable extraction rules.
   - Updated `BaseStepModel` to include new attributes for regex handling and variable extraction.