### PR TITLE
update output transformations to cover both steps and provider config output

### DIFF
--- a/prich/core/engine.py
+++ b/prich/core/engine.py
@@ -170,7 +170,7 @@ def run_command_step(template: TemplateModel, step: PythonStep | CommandStep, va
                 result = subprocess.run(cmd, capture_output=True, text=True, check=False)
         else:
             result = subprocess.run(cmd, capture_output=True, text=True, check=False)
-        return result.stdout.strip()
+        return result.stdout
     except subprocess.CalledProcessError as e:
         raise click.ClickException(f"Execution error in {method}: {e.stderr}")
     except Exception as e:
@@ -338,7 +338,7 @@ def send_to_llm(template: TemplateModel, step: LLMStep, provider: str, config: C
                 system=prompt_fields.system if prompt_fields else None,
                 user=prompt_fields.user if prompt_fields else None
             )
-        step_output = response.strip()
+        step_output = selected_provider.postprocess_output(response)
         if (is_verbose() or step.output_console) and not llm_provider.show_response and not is_quiet():
             console_print(step_output, markup=False)
     except Exception as e:
@@ -405,7 +405,8 @@ def run_template(template_id, **kwargs):
             if is_verbose():
                 if step.extract_vars or step.output_regex or step.strip_output_prefix or step.slice_output_start or step.slice_output_end:
                     console_print(f"[dim]Output: '{step_output}'[/dim]")
-            step_output = step.postprocess_output(output=step_output, variables=variables)
+            step.postprocess_extract_vars(output=step_output, variables=variables)
+            step_output = step.postprocess_output(output=step_output)
             if is_verbose():
                 if step.extract_vars:
                     for spec in step.extract_vars:

--- a/prich/models/config_providers.py
+++ b/prich/models/config_providers.py
@@ -1,10 +1,12 @@
-from pydantic import BaseModel, Field, ConfigDict
+from pydantic import Field, ConfigDict
 from typing import Literal, Optional, List, Tuple
+from prich.models.output_shaping import BaseOutputShapingModel
 
 
-class BaseProviderModel(BaseModel):
+class BaseProviderModel(BaseOutputShapingModel):
     model_config = ConfigDict(extra='forbid')
     name: str | None = Field(default=None, exclude=True)  # will be injected
+
     mode: Optional[str] = None
 
     def model_post_init(self, __context):

--- a/prich/models/output_shaping.py
+++ b/prich/models/output_shaping.py
@@ -1,0 +1,35 @@
+from typing import Optional
+from pydantic import BaseModel
+
+
+class BaseOutputShapingModel(BaseModel):
+
+    # output shaping
+    strip_output: Optional[bool] = True
+    strip_output_prefix: Optional[str] = None
+
+    slice_output_start: Optional[int] = None
+    slice_output_end: Optional[int] = None
+
+    # regex
+    output_regex: Optional[str] = None                    # transforms main output
+
+    def postprocess_output(self, output: str):
+        """PostProcess output - Transform string text"""
+        import re
+        out = output
+        if self.strip_output:
+            out = out.strip()
+
+        if self.strip_output_prefix and out.startswith(self.strip_output_prefix):
+            out = out[len(self.strip_output_prefix):]
+
+        if self.slice_output_start or self.slice_output_end:
+            out = out[self.slice_output_start:self.slice_output_end]
+
+        if self.output_regex:
+            m = re.search(self.output_regex, out)
+            if m:
+                out = m.group(1) if m.groups() else m.group(0)
+
+        return out

--- a/tests/test_run_template.py
+++ b/tests/test_run_template.py
@@ -151,8 +151,6 @@ get_run_template_CASES = [
             "folder": "."
         # ),
         },
-      "expected_exception": click.ClickException,
-      "expected_exception_message": "Execution error in ",
     },
     {"id": "no_cmd_found", "template":
         # TemplateModel(


### PR DESCRIPTION
The diff introduces a **refactoring of output processing logic** across multiple files, moving from ad-hoc stripping and transformation to a centralized, modular system. Key changes include:

1. **New `BaseOutputShapingModel`** in `output_shaping.py`:
   - Defines configurable output shaping parameters (e.g., `strip_output`, `slice_output`, regex).
   - Implements `postprocess_output()` to handle transformations like stripping, slicing, and regex extraction.

2. **Inheritance Refactoring**:
   - `BaseProviderModel` in `config_providers.py` now inherits from `BaseOutputShapingModel`.
   - `BaseStepModel` in `template.py` now inherits from `BaseOutputShapingModel`, unifying output processing logic.

3. **Code Modularization**:
   - Removed direct stripping of outputs (e.g., `strip()`) in favor of using `postprocess_output()` from `BaseOutputShapingModel`.
   - Split `postprocess_output()` into `postprocess_extract_vars()` (for variable extraction) and `postprocess_output()` (for final transformations).

4. **Test Adjustments**:
   - Removed or commented out exception expectations in `test_run_template.py`, likely due to changes in error handling.