### PR TITLE
Template llm prompt refactoring

### DIFF
--- a/prich/cli/init_cmd.py
+++ b/prich/cli/init_cmd.py
@@ -44,12 +44,12 @@ def init(global_init: bool, force: bool):
             )
         },
         provider_modes=[
-            ProviderModeModel(name="plain", prompt="{{ prompt }}"),
-            ProviderModeModel(name="flat", prompt="""{% if system %}### System:\n{{ system }}\n\n{% endif %}### User:\n{{ user }}\n\n### Assistant:"""),
-            ProviderModeModel(name="mistral-instruct", prompt="""<s>[INST]\n{% if system %}{{ system }}\n\n{% endif %}{{ user }}\n[/INST]"""),
-            ProviderModeModel(name="llama2-chat", prompt="""<s>[INST]\n{% if system %}{{ system }}\n\n{% endif %}{{ user }}\n[/INST]"""),
-            ProviderModeModel(name="anthropic", prompt="""Human: {% if system %}{{ system }}\n\n{% endif %}{{ user }}\n\nAssistant:"""),
-            ProviderModeModel(name="chatml", prompt="""[{% if system %}{"role": "system", "content": "{{ system }}" },{% endif %}{"role": "user", "content": "{{ user }}" }]""")
+            ProviderModeModel(name="plain", prompt="{{ input }}"),
+            ProviderModeModel(name="flat", prompt="""{% if instructions %}### System:\n{{ instructions }}\n\n{% endif %}### User:\n{{ input }}\n\n### Assistant:"""),
+            # ProviderModeModel(name="mistral-instruct", prompt="""<s>[INST]\n{% if instructions %}{{ instructions }}\n\n{% endif %}{{ input }}\n[/INST]"""),
+            # ProviderModeModel(name="llama2-chat", prompt="""<s>[INST]\n{% if instructions %}{{ instructions }}\n\n{% endif %}{{ input }}\n[/INST]"""),
+            # ProviderModeModel(name="anthropic", prompt="""Human: {% if instructions %}{{ instructions }}\n\n{% endif %}{{ input }}\n\nAssistant:"""),
+            # ProviderModeModel(name="chatml", prompt="""[{% if instructions %}{"role": "system", "content": "{{ instructions }}" },{% endif %}{"role": "user", "content": "{{ input }}" }]""")
         ]
     )
 

--- a/prich/cli/templates.py
+++ b/prich/cli/templates.py
@@ -11,7 +11,7 @@ from prich.core.loaders import get_loaded_templates, get_loaded_config, get_load
 from prich.core.utils import console_print, is_valid_template_id, get_prich_dir, get_prich_templates_dir, shorten_path
 from prich.cli.venv_utils import install_template_python_dependencies
 from prich.cli.template_utils import directory_hash
-from prich.models.template import TemplateModel, VariableDefinition, LLMStep, PromptFields
+from prich.models.template import TemplateModel, VariableDefinition, LLMStep
 
 def _download_zip(url: str) -> Path:
     """ Download zip file into temporary file and return path to it """
@@ -115,7 +115,7 @@ def template_install(path: str, force: bool, no_venv: bool, global_install: bool
                         _download_file(f"{remote_templates_repo_path}/{template_to_install.id}/{file_to_download}", download_to_file)
             except Exception as e:
                 raise click.ClickException(f"Failed to download remote template files: {str(e)}")
-            downloaded_template_hash = directory_hash(tmp_path)
+            downloaded_template_hash, files = directory_hash(tmp_path)
             if downloaded_template_hash != template_to_install.folder_checksum:
                 console_print(f"[yellow]Downloaded template folder checksum is not matching with mentioned in the manifest![/yellow]")
                 console_print(f"[yellow]From the manifest: {template_to_install.folder_checksum}[/yellow]")
@@ -268,10 +268,8 @@ def create_template(template_id: str, global_only: bool, edit: bool):
             LLMStep(
                 name="Ask to generate text",
                 type="llm",
-                prompt=PromptFields(
-                    system="You are {{ role }}",
-                    user="Generate text about {{ topic }}"
-                )
+                instructions="You are {{ role }}",
+                input="Generate text about {{ topic }}"
             )
         ],
         variables=[

--- a/prich/core/utils.py
+++ b/prich/core/utils.py
@@ -50,7 +50,7 @@ def is_piped() -> bool:
 def console_print(message: str = "", end: str = "\n", markup = None, flush: bool = None):
     """ Print to console wrapper """
     if not is_quiet() and not is_only_final_output():
-        console.print(message, end=end, markup=markup)
+        console.print(message, end=end, markup=markup, crop=False, no_wrap=True)
 
 def is_valid_template_id(template_id) -> bool:
     """ Validate Name Pattern: lowercase letters, numbers, hyphen, optional underscores, and no other characters"""

--- a/prich/llm_providers/echo_provider.py
+++ b/prich/llm_providers/echo_provider.py
@@ -7,8 +7,8 @@ class EchoProvider(LLMProvider):
         self.mode: str = provider.mode
         self.show_response: bool = False
 
-    def send_prompt(self, prompt: str = None, system: str = None, user: str = None) -> str:
+    def send_prompt(self, prompt: str = None, instructions: str = None, input_: str = None) -> str:
         if prompt:
             return prompt
         else:
-            return f"{system}\n{user}"
+            return f"{instructions}\n{input_}"

--- a/prich/llm_providers/llm_provider_interface.py
+++ b/prich/llm_providers/llm_provider_interface.py
@@ -7,6 +7,6 @@ class LLMProvider(ABC):
     show_response: bool
 
     @abstractmethod
-    def send_prompt(self, prompt: str = None, system: str = None, user: str = None) -> str:
+    def send_prompt(self, prompt: str = None, instructions: str = None, input_: str = None) -> str:
         """Send a prompt to the LLM and return the response. Use prompt with full model prompt template and system/user when model supports field templates."""
         pass

--- a/prich/llm_providers/mlx_local_provider.py
+++ b/prich/llm_providers/mlx_local_provider.py
@@ -47,8 +47,8 @@ class MLXLocalProvider(LLMProvider, LazyOptionalProvider):
 
         self.client = True
 
-    def send_prompt(self, prompt: str = None, system: str = None, user: str = None) -> str:
-        if system or user:
+    def send_prompt(self, prompt: str = None, instructions: str = None, input_: str = None) -> str:
+        if instructions or input_:
             raise click.ClickException("mxl_local provider requires provider mode")
         self._ensure_client()
         text = []

--- a/prich/llm_providers/ollama_provider.py
+++ b/prich/llm_providers/ollama_provider.py
@@ -45,7 +45,7 @@ class OllamaProvider(LLMProvider, LazyOptionalProvider):
                 f"Install it with: `ollama pull {self.provider.model}`"
             )
 
-    def send_prompt(self, prompt: str = None, system: str = None, user: str = None) -> str:
+    def send_prompt(self, prompt: str = None, instructions: str = None, input_: str = None) -> str:
         self._ensure_client()
         text = []
         try:
@@ -53,14 +53,14 @@ class OllamaProvider(LLMProvider, LazyOptionalProvider):
                 if type(prompt) != str:
                     prompt = json.dumps(prompt)
             else:
-                prompt = user
+                prompt = input_
             payload = {
                 "model": self.provider.model,
                 "prompt": prompt,
                 "options": self.provider.options or {}
             }
-            if system:
-                payload['system'] = system
+            if instructions:
+                payload['system'] = instructions
             if not is_only_final_output() and not is_quiet() and self.provider.stream is not None:
                 payload["stream"] = self.provider.stream
             else:

--- a/prich/llm_providers/openai_provider.py
+++ b/prich/llm_providers/openai_provider.py
@@ -25,16 +25,16 @@ class OpenAIProvider(LLMProvider, LazyOptionalProvider):
             configuration['api_key'] = replace_env_vars(configuration['api_key'], False)
         self.client = OpenAI(**configuration)
 
-    def send_prompt(self, prompt: str = None, system: str = None, user: str = None) -> str:
+    def send_prompt(self, prompt: str = None, instructions: str = None, input_: str = None) -> str:
         self._ensure_client()
         try:
             if prompt:
                 messages = json.loads(prompt)
             else:
                 messages = []
-                if system:
-                    messages.append({"role": "system", "content": system})
-                messages.append({"role": "user", "content": user})
+                if instructions:
+                    messages.append({"role": "system", "content": instructions})
+                messages.append({"role": "user", "content": input_})
             options = self.provider.options if self.provider.options is not None else {}
             options['messages'] = messages
             response = self.client.chat.completions.create(**options)

--- a/prich/llm_providers/stdin_consumer_provider.py
+++ b/prich/llm_providers/stdin_consumer_provider.py
@@ -14,8 +14,8 @@ class STDINConsumerProvider(LLMProvider):
         import re
         return re.sub(r'\x1b\[[0-9;]*m', '', text)
 
-    def send_prompt(self, prompt: str = None, system: str = None, user: str = None) -> str:
-        if system or user:
+    def send_prompt(self, prompt: str = None, instructions: str = None, input_: str = None) -> str:
+        if instructions or input_:
             raise click.ClickException("stdin consumer provider requires provider mode")
         cmd = [self.provider.call]
         if self.provider.args:

--- a/prich/models/template.py
+++ b/prich/models/template.py
@@ -24,13 +24,6 @@ class VariableDefinition(BaseModel):
 
 # Template Pipeline Steps
 
-class PromptFields(BaseModel):
-    model_config = ConfigDict(extra='forbid')
-    system: Optional[str] = None
-    user: Optional[str] = None
-    prompt: Optional[str] = None
-
-
 class ValidateStepOutput(BaseModel):
     model_config = ConfigDict(extra='forbid')
     match: Optional[str] = None
@@ -88,8 +81,18 @@ class BaseStepModel(BaseOutputShapingModel):
 
 class LLMStep(BaseStepModel):
     type: Literal["llm"]
-    prompt: PromptFields
+
+    # overload provider mentioned in the config
     provider: Optional[str] = None
+
+    # prompt
+    instructions: Optional[str] = None
+    input: Optional[str] = None
+
+    # These fields are injected at runtime
+    rendered_instructions: Optional[str] = Field(default=None, exclude=True)
+    rendered_input: Optional[str] = Field(default=None, exclude=True)
+    rendered_prompt: Optional[str] = Field(default=None, exclude=True)
 
 
 class PythonStep(BaseStepModel):

--- a/tests/fixtures/config.py
+++ b/tests/fixtures/config.py
@@ -11,39 +11,39 @@ providers:
     mode: "flat"
 provider_modes:
   - name: plain
-    prompt: '{{ prompt }}'
+    prompt: '{{ input }}'
   - name: flat
     prompt: |-
-      {% if system %}### System:
-      {{ system }}
+      {% if instructions %}### System:
+      {{ instructions }}
 
       {% endif %}### User:
-      {{ user }}
+      {{ input }}
 
       ### Assistant:
   - name: mistral-instruct
     prompt: |-
       <s>[INST]
-      {% if system %}{{ system }}
+      {% if instructions %}{{ instructions }}
 
-      {% endif %}{{ user }}
+      {% endif %}{{ input }}
       [/INST]
   - name: llama2-chat
     prompt: |-
       <s>[INST]
-      {% if system %}{{ system }}
+      {% if instructions %}{{ instructions }}
 
-      {% endif %}{{ user }}
+      {% endif %}{{ input }}
       [/INST]
   - name: anthropic
     prompt: |-
-      Human: {% if system %}{{ system }}
+      Human: {% if instructions %}{{ instructions }}
 
-      {% endif %}{{ user }}
+      {% endif %}{{ input }}
 
       Assistant:
   - name: chatml
-    prompt: '[{% if system %}{"role": "system", "content": "{{ system }}"},{% endif %}{"role": "user", "content": "{{ user }}"}]'
+    prompt: '[{% if instructions %}{"role": "system", "content": "{{ instructions }}"},{% endif %}{"role": "user", "content": "{{ input }}"}]'
 settings:
   editor: "vim"
   default_provider: "show_prompt"
@@ -61,14 +61,14 @@ providers:
     provider_type: echo
 provider_modes:
   - name: plain
-    prompt: '{{ prompt }}'
+    prompt: '{{ input }}'
   - name: flat
     prompt: |-
-      {% if system %}### System:
-      {{ system }}
+      {% if instructions %}### System:
+      {{ instructions }}
 
       {% endif %}### User:
-      {{ user }}
+      {{ input }}
 
       ### Assistant:
 settings: 
@@ -89,39 +89,39 @@ providers:
     provider_type: echo
 provider_modes:
   - name: plain
-    prompt: '{{ prompt }}'
+    prompt: '{{ input }}'
   - name: flat
     prompt: |-
-      {% if system %}### System:
-      {{ system }}
+      {% if instructions %}### System:
+      {{ instructions }}
 
       {% endif %}### User:
-      {{ user }}
+      {{ input }}
 
       ### Assistant:
   - name: mistral-instruct
     prompt: |-
       <s>[INST]
-      {% if system %}{{ system }}
+      {% if instructions %}{{ instructions }}
 
-      {% endif %}{{ user }}
+      {% endif %}{{ input }}
       [/INST]
   - name: llama2-chat
     prompt: |-
       <s>[INST]
-      {% if system %}{{ system }}
+      {% if instructions %}{{ instructions }}
 
-      {% endif %}{{ user }}
+      {% endif %}{{ input }}
       [/INST]
   - name: anthropic
     prompt: |-
-      Human: {% if system %}{{ system }}
+      Human: {% if instructions %}{{ instructions }}
 
-      {% endif %}{{ user }}
+      {% endif %}{{ input }}
 
       Assistant:
   - name: chatml
-    prompt: '[{% if system %}{"role": "system", "content": "{{ system }}"},{% endif %}{"role": "user", "content": "{{ user }}"}]'
+    prompt: '[{% if instructions %}{"role": "system", "content": "{{ instructions }}"},{% endif %}{"role": "user", "content": "{{ input }}"}]'
 settings: 
     default_provider: "show_prompt"
     editor: "vi"

--- a/tests/fixtures/templates.py
+++ b/tests/fixtures/templates.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from prich.models.file_scope import FileScope
 
-from prich.models.template import TemplateModel, VariableDefinition, PythonStep, LLMStep, PromptFields, CommandStep, \
+from prich.models.template import TemplateModel, VariableDefinition, PythonStep, LLMStep, CommandStep, \
     ValidateStepOutput
 from tests.generate.templates import generate_template, templates
 
@@ -77,10 +77,8 @@ def template(tmp_path):
             LLMStep(
                 name="llm step",
                 type="llm",
-                prompt=PromptFields(
-                    system="Hi {{ name }}",
-                    user="Analyse `{{ test_output }}`?"
-                ),
+                instructions="Hi {{ name }}",
+                input="Analyse `{{ test_output }}`?",
                 output_variable="llm_response",
                 output_file="test_llm_response.txt",
                 when="1==1",
@@ -140,10 +138,8 @@ def shared_venv_template(tmp_path):
             LLMStep(
                 name="LLM Step",
                 type="llm",
-                prompt=PromptFields(
-                    system="You are {{ name }}",
-                    user="Analyse `{{ test_output }}`"
-                )
+                instructions="You are {{ name }}",
+                input="Analyse `{{ test_output }}`"
             )
         ],
         source=FileScope.LOCAL,
@@ -163,9 +159,8 @@ variables: []
 steps:
   - name: "LLM step"
     type: llm
-    prompt:
-      system: "System prompt"
-      user: "User prompt"
+    instructions: "System prompt"
+    input: "User prompt"
 """
 
 INVALID_TEMPLATE_YAML = """
@@ -175,8 +170,7 @@ variables: []
 steps:
   - name: "LLM_step"
     type: llm
-    prompt: 
-      system: "Missing name"
+    instructions: "Missing name"
 """
 
 @pytest.fixture

--- a/tests/generate/templates.py
+++ b/tests/generate/templates.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from faker import Faker
 from prich.models.file_scope import FileScope
 
-from prich.models.template import TemplateModel, VariableDefinition, PythonStep, LLMStep, PromptFields
+from prich.models.template import TemplateModel, VariableDefinition, PythonStep, LLMStep
 
 faker = Faker()
 
@@ -42,10 +42,8 @@ def generate_template(prich_path: Path = Path("./test"), template_id: str=None, 
             LLMStep(
                 name="LLM Step",
                 type="llm",
-                prompt=PromptFields(
-                    system=f"You are {{ name }}, {faker.text(80)}",
-                    user=f"Analyse `{{ test_output }}`, {faker.text(40)}"
-                )
+                instructions=f"You are {{ name }}, {faker.text(80)}",
+                input=f"Analyse `{{ test_output }}`, {faker.text(40)}"
             )
         ],
         source=FileScope.LOCAL if not global_location else FileScope.GLOBAL,

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -57,11 +57,11 @@ def test_stdin_consumer(case):
         user = case["prompt"].get("user")
     if case.get("expected_exception"):
         with pytest.raises(case.get("expected_exception")) as e:
-            stdin_consumer.send_prompt(prompt=prompt, system=system, user=user)
+            stdin_consumer.send_prompt(prompt=prompt, instructions=system, input_=user)
         if case.get("expected_exception_messages"):
             for message in case.get("expected_exception_messages"):
                 assert message in str(e)
     else:
-        result = stdin_consumer.send_prompt(prompt=prompt, system=system, user=user)
+        result = stdin_consumer.send_prompt(prompt=prompt, instructions=system, input_=user)
         if case.get("expected_output"):
             assert case.get("expected_output") == result

--- a/tests/test_run_template.py
+++ b/tests/test_run_template.py
@@ -6,7 +6,7 @@ from click.testing import CliRunner
 from prich.cli.config import list_providers, show_config, edit_config
 from prich.core.engine import run_template
 from prich.core.state import _loaded_templates
-from prich.models.template import TemplateModel, PromptFields, VariableDefinition, PythonStep, CommandStep, LLMStep, \
+from prich.models.template import TemplateModel, VariableDefinition, PythonStep, CommandStep, LLMStep, \
     RenderStep, ValidateStepOutput
 from tests.fixtures.config import basic_config
 from tests.fixtures.paths import mock_paths
@@ -23,10 +23,8 @@ get_run_template_CASES = [
                 LLMStep(
                     name="Ask",
                     type="llm",
-                    prompt=PromptFields(
-                        system="system",
-                        user="user"
-                    )
+                    instructions="system",
+                    input="user"
                 )
             ]
         # ),
@@ -66,10 +64,8 @@ get_run_template_CASES = [
                 LLMStep(
                     name="Ask",
                     type="llm",
-                    prompt=PromptFields(
-                        system="system",
-                        user="user"
-                    ),
+                    instructions="system",
+                    input="user",
                     output_file="test_llm_response.txt"
                 ),
             ],
@@ -200,10 +196,8 @@ get_run_template_CASES = [
                 LLMStep(
                     name="Ask",
                     type="llm",
-                    prompt=PromptFields(
-                        system="system: test_var1='{{ test_var1 }}'; test_var2='{{ test_var2 }}'; test_var3='{{ test_var3 }}'; test_var4='{{ test_var4 }}'; test_var5='{% for test_var5_item in test_var5 %}{{ test_var5_item }}{% endfor %}'; test_var6='{% for test_var6_item in test_var6 %}{{ test_var6_item }}{% endfor %}';",
-                        user="user: test_var1='{{ test_var1 }}'; test_var2='{{ test_var2 }}'; test_var3='{{ test_var3 }}'; test_var4='{{ test_var4 }}'; test_var5='{% for test_var5_item in test_var5 %}{{ test_var5_item }}{% endfor %}'; test_var6='{% for test_var6_item in test_var6 %}{{ test_var6_item }}{% endfor %}';",
-                    )
+                    instructions="system: test_var1='{{ test_var1 }}'; test_var2='{{ test_var2 }}'; test_var3='{{ test_var3 }}'; test_var4='{{ test_var4 }}'; test_var5='{% for test_var5_item in test_var5 %}{{ test_var5_item }}{% endfor %}'; test_var6='{% for test_var6_item in test_var6 %}{{ test_var6_item }}{% endfor %}';",
+                    input="user: test_var1='{{ test_var1 }}'; test_var2='{{ test_var2 }}'; test_var3='{{ test_var3 }}'; test_var4='{{ test_var4 }}'; test_var5='{% for test_var5_item in test_var5 %}{{ test_var5_item }}{% endfor %}'; test_var6='{% for test_var6_item in test_var6 %}{{ test_var6_item }}{% endfor %}';",
                 )
             ],
             "variables": [
@@ -610,9 +604,7 @@ def test_invalid_template_missing_required_variable(monkeypatch, basic_config, t
           LLMStep(
               name="llm_step",
               type="llm",
-              prompt=PromptFields(
-                  user="Hello {{ must_be_set }}"
-              )
+              input="Hello {{ must_be_set }}"
           )
         ],
         source="local",


### PR DESCRIPTION
Refactoring of the prompt handling mechanism, transitioning from a nested `PromptFields` structure to a simplified model with direct `instructions` and `input` fields.

### **Key Structural Changes**
- **Replacement of `PromptFields`**:  
  The `PromptFields` class (which previously encapsulated `system` and `user` fields) has been deprecated. Instead, the `LLMStep` now directly uses `instructions` and `input` fields.  
  - **Before**:  
    ```python
    LLMStep(prompt=PromptFields(system="...", user="..."))
    ```
  - **After**:  
    ```python
    LLMStep(instructions="...", input="...")
    ```

- **Simplification of Prompt Handling**:  
  This change removes the need for a nested structure, making the code more readable and reducing boilerplate. The `instructions` field likely represents system-level prompts (e.g., task descriptions), while `input` holds user-facing prompts.
