### PR TITLE
add exit code validation; update stdin provider error handling

### DIFF
--- a/prich/core/engine.py
+++ b/prich/core/engine.py
@@ -118,10 +118,13 @@ def validate_step_output(validate_step: ValidateStepOutput, value: str, variable
     return False
 
 def validate_step_exit_code(validate_step: ValidateStepOutput, exit_code: int, variables: Dict[str, any]) -> bool:
-    if validate_step.match_exit_code is not None and str(exit_code) != str(expand_vars([validate_step.match_exit_code], variables)[0]):
-        return False
-    if validate_step.not_match_exit_code is not None and str(exit_code) == str(expand_vars([validate_step.not_match_exit_code], variables)[0]):
-        return False
+    try:
+        if validate_step.match_exit_code is not None and exit_code != int(expand_vars([validate_step.match_exit_code], variables)[0]):
+            return False
+        if validate_step.not_match_exit_code is not None and exit_code == int(expand_vars([validate_step.not_match_exit_code], variables)[0]):
+            return False
+    except Exception as e:
+        raise click.ClickException(f"Failed to validate step exit code: {str(e)}")
     return True
 
 def run_command_step(template: TemplateModel, step: PythonStep | CommandStep, variables: Dict[str, any]) -> Tuple[str, int]:

--- a/prich/llm_providers/stdin_consumer_provider.py
+++ b/prich/llm_providers/stdin_consumer_provider.py
@@ -26,9 +26,11 @@ class STDINConsumerProvider(LLMProvider):
                 input=prompt,
                 capture_output=True,
                 text=True,
-                check=True
+                check=False
             )
         except Exception as e:
             raise click.ClickException(f"STDIN consumer provider error: {str(e)}")
+        if response.returncode != 0:
+            raise click.ClickException(f"stdout:\n{response.stdout}\n\nstderr:\n{response.stderr}\n\nError during STDIN consumer provider execution, exit code {response.returncode}.")
         clean_output = self.clear_ansi(response.stdout)
         return clean_output

--- a/prich/models/template.py
+++ b/prich/models/template.py
@@ -26,8 +26,16 @@ class VariableDefinition(BaseModel):
 
 class ValidateStepOutput(BaseModel):
     model_config = ConfigDict(extra='forbid')
+
+    # Output validations
     match: Optional[str] = None
     not_match: Optional[str] = None
+
+    # Validations for command executions
+    match_exit_code: Optional[str | int] = None
+    not_match_exit_code: Optional[str | int] = None
+
+    # Action
     on_fail: Optional[Literal["error", "warn", "skip", "continue"]] = "error"
     message: Optional[str] = None
 

--- a/tests/test_run_template.py
+++ b/tests/test_run_template.py
@@ -254,7 +254,7 @@ get_run_template_CASES = [
       "expected_exception": click.ClickException,
       "expected_exception_message": "No steps found in template test-tpl.",
      },
-    {"id": "run_cmd_and_validate_error", "template":
+    {"id": "run_python_and_validate_error", "template":
         # TemplateModel(
         {
             "id": "test-tpl",
@@ -268,6 +268,107 @@ get_run_template_CASES = [
                     validate=ValidateStepOutput(
                         match="^est",
                         not_match="test",
+                        on_fail="error"
+                    )
+                ),
+            ],
+            "folder": "."
+        # ),
+        },
+     "expected_exception": click.ClickException,
+     "expected_exception_message": "Validation failed for step output",
+     },
+    {"id": "run_cmd_and_validate_error_and_exitcode", "template":
+        # TemplateModel(
+        {
+            "id": "test-tpl",
+            "name": "Test TPL",
+            "steps": [
+                CommandStep(
+                    name="Preprocess python",
+                    type="command",
+                    call="ls",
+                    args=["------ttgtgtg"],
+                    validate=ValidateStepOutput(
+                        not_match="test",
+                        match_exit_code=1,
+                        on_fail="error"
+                    )
+                ),
+            ],
+            "folder": "."
+        # ),
+        },
+     },
+    {"id": "run_cmd_and_validate_error_and_exitcode_str", "template":
+        # TemplateModel(
+        {
+            "id": "test-tpl",
+            "name": "Test TPL",
+            "steps": [
+                CommandStep(
+                    name="Preprocess python",
+                    type="command",
+                    call="ls",
+                    args=["------ttgtgtg"],
+                    validate=ValidateStepOutput(
+                        not_match="test",
+                        match_exit_code="{{test_error_code}}",
+                        on_fail="error"
+                    )
+                ),
+            ],
+            "variables": [
+                VariableDefinition(
+                    name="test_error_code",
+                    type="int",
+                    default=1
+                )
+            ],
+            "folder": "."
+        # ),
+        },
+     },
+    {"id": "run_cmd_and_validate_error_and_fail_exitcode", "template":
+        # TemplateModel(
+        {
+            "id": "test-tpl",
+            "name": "Test TPL",
+            "steps": [
+                CommandStep(
+                    name="Preprocess python",
+                    type="command",
+                    call="echo1",
+                    args=["test"],
+                    validate=ValidateStepOutput(
+                        match="No such file or directory: 'echo1'",
+                        not_match="test",
+                        match_exit_code=1,
+                        on_fail="error"
+                    )
+                ),
+            ],
+            "folder": "."
+        # ),
+        },
+     "expected_exception": click.ClickException,
+     "expected_exception_message": "No such file or directory: 'echo1'",
+     },
+    {"id": "run_cmd_and_validate_error_and_exitcode", "template":
+        # TemplateModel(
+        {
+            "id": "test-tpl",
+            "name": "Test TPL",
+            "steps": [
+                PythonStep(
+                    name="Preprocess python",
+                    type="python",
+                    call="echo.py",
+                    args=["test"],
+                    validate=ValidateStepOutput(
+                        match="^est",
+                        not_match="test",
+                        match_exit_code=0,
                         on_fail="error"
                     )
                 ),

--- a/tests/test_run_template.py
+++ b/tests/test_run_template.py
@@ -354,6 +354,31 @@ get_run_template_CASES = [
      "expected_exception": click.ClickException,
      "expected_exception_message": "No such file or directory: 'echo1'",
      },
+    {"id": "run_cmd_and_validate_fail_exitcode_format", "template":
+        # TemplateModel(
+        {
+            "id": "test-tpl",
+            "name": "Test TPL",
+            "steps": [
+                CommandStep(
+                    name="Preprocess python",
+                    type="command",
+                    call="echo",
+                    args=["test"],
+                    validate=ValidateStepOutput(
+                        match="No such file or directory: 'echo1'",
+                        not_match="test",
+                        match_exit_code="hello",
+                        on_fail="error"
+                    )
+                ),
+            ],
+            "folder": "."
+        # ),
+        },
+     "expected_exception": click.ClickException,
+     "expected_exception_message": "invalid literal for int()",
+     },
     {"id": "run_cmd_and_validate_error_and_exitcode", "template":
         # TemplateModel(
         {


### PR DESCRIPTION
1. **Enhanced Step Validation:**
   - Introduced `validate_step_exit_code` to check exit codes from command executions.
   - Updated `run_command_step` to return both output and exit code (`tuple[str, int]`).
   - Added `match_exit_code` and `not_match_exit_code` fields to `ValidateStepOutput` for exit code-based validation.

2. **Type Safety Improvements:**
   - Annotated return types (e.g., `expand_vars` now returns `list`).
   - Updated parameter types (e.g., `variables` in `validate_step_output` is now `Dict[str, any]`).

3. **Error Handling Enhancements:**
   - Modified `subprocess.run` in `stdin_consumer_provider` to use `check=False` and explicitly check exit codes.
   - Added new test cases for exit code validation in both `CommandStep` and `PythonStep`.

4. **Test Case Refactoring:**
   - Renamed `test_validate_sep_output` to `test_validate_step_output` for consistency.
   - Updated test expectations to handle return values and exit codes in `run_command_step`.