### PR TITLE
add openai streaming and small updates and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@
 - **Secure venv Management**: Default (`.prich/venv/`) and custom Python venvs (e.g., `.prich/templates/code_review/scripts/venv`) isolate dependencies.
 - **Simple CLI**: Commands like `prich run` and `prich install` streamline workflows.
 
-> **Supported LLMs**: Ollama API, OpenAI API, MLX LM, STDIN
+> **Supported LLMs**: Ollama API, OpenAI API, MLX LM, STDIN (different cli tools like q chat, mlx_lm.generate, etc.)
 
 ## Quick Start
-1. Install `prich` tool (see `Installation`)
+1. Install `prich` tool `pipx install git+https://github.com/oleks-dev/prich` (see `Installation`)
 2. Initialize config (use global for the start): `prich init --global`
-3. Create simple example template (`prich create <template_id>`): `prich create my-template`
+3. Create simple example template (`prich create <template_id> --global`): `prich create my-template -g`
 4. Run template (`prich run <template_id>`): `prich run my-template`
 > Note: By default prich will set up and use echo provider which just outputs the rendered template  
 > To use it with LLM see `Configure .prich/config.yaml` and follow it to add your LLM provider  
@@ -540,16 +540,32 @@ settings:
       slice_output_start: Optional[int] = None  # slice step output from character number
       slice_output_end: Optional[int] = None  # slice step output to character number
     ```
-  Example:
+  Examples:
+  - Amazon Q Chat CLI  
     ```yaml
       qchat:
         provider_type: stdin_consumer
-        mode: flat
+        mode: plain
         call: q
         args:
           - chat
           - --no-interactive
+        strip_output_prefix: "> "
     ```
+  - MLX LM Generate CLI
+    ```yaml
+      mlx-mistral-7b-cli:
+        provider_type: stdin_consumer
+        mode: plain
+        call: "mlx_lm.generate"
+        args:
+          - "--model"
+          - "/Users/guest/.cache/huggingface/hub/models--mlx-community--Mistral-7B-Instruct-v0.3-4bit/snapshots/a4b8f870474b0eb527f466a03fbc187830d271f5"
+          - "--prompt"
+          - "-"
+        output_regex: "^==========\\n((?:.|\\n)+)\\n\\=\\=\\=\\=\\=\\=\\=\\=\\=\\=(?:.|\\n)+$"
+    ```
+
 
 ### Provider Mode `mode`  
 Use to specify how the prompt would be constructed for the LLM, you can modify or add your own as needed in the `config.yaml` - `provider_modes`.

--- a/prich/cli/init_cmd.py
+++ b/prich/cli/init_cmd.py
@@ -44,7 +44,7 @@ def init(global_init: bool, force: bool):
             )
         },
         provider_modes=[
-            ProviderModeModel(name="plain", prompt="{{ input }}"),
+            ProviderModeModel(name="plain", prompt="{% if instructions %}{{ instructions }}\n{% endif %}{{ input }}"),
             ProviderModeModel(name="flat", prompt="""{% if instructions %}### System:\n{{ instructions }}\n\n{% endif %}### User:\n{{ input }}\n\n### Assistant:"""),
             # ProviderModeModel(name="mistral-instruct", prompt="""<s>[INST]\n{% if instructions %}{{ instructions }}\n\n{% endif %}{{ input }}\n[/INST]"""),
             # ProviderModeModel(name="llama2-chat", prompt="""<s>[INST]\n{% if instructions %}{{ instructions }}\n\n{% endif %}{{ input }}\n[/INST]"""),

--- a/prich/core/engine.py
+++ b/prich/core/engine.py
@@ -201,7 +201,7 @@ def render_template(template_text: str, variables: dict = Dict[str, str]) -> str
     }
     variables["builtin"] = builtin
     try:
-        rendered_text = get_jinja_env("params", conditional_expression_only=True).from_string(template_text).render(**variables).strip()
+        rendered_text = get_jinja_env("params").from_string(template_text).render(**variables).strip()
     except Exception as e:
         raise click.ClickException(f"Render jinja error: {str(e)}")
     return rendered_text

--- a/prich/llm_providers/openai_provider.py
+++ b/prich/llm_providers/openai_provider.py
@@ -1,7 +1,9 @@
 import json
+from contextlib import nullcontext
+
 import click
 
-from prich.core.utils import replace_env_vars
+from prich.core.utils import replace_env_vars, console, is_quiet, is_only_final_output, console_print
 from prich.models.config_providers import OpenAIProviderModel
 from prich.llm_providers.llm_provider_interface import LLMProvider
 from prich.llm_providers.base_optional_provider import LazyOptionalProvider
@@ -15,6 +17,7 @@ class OpenAIProvider(LLMProvider, LazyOptionalProvider):
         self.name = name
         self.provider = provider
         self.client = None
+        self.show_response = True
 
     def _ensure_client(self):
         if self.client:
@@ -27,6 +30,7 @@ class OpenAIProvider(LLMProvider, LazyOptionalProvider):
 
     def send_prompt(self, prompt: str = None, instructions: str = None, input_: str = None) -> str:
         self._ensure_client()
+        text = []
         try:
             if prompt:
                 messages = json.loads(prompt)
@@ -37,8 +41,35 @@ class OpenAIProvider(LLMProvider, LazyOptionalProvider):
                 messages.append({"role": "user", "content": input_})
             options = self.provider.options if self.provider.options is not None else {}
             options['messages'] = messages
-            response = self.client.chat.completions.create(**options)
-            return response.choices[0].message.content
+
+            status = console.status("Thinking...") if not is_quiet() and not is_only_final_output() else nullcontext()
+
+            with status:
+                if options['stream']:
+                    # Streaming mode
+                    with self.client.chat.completions.create(**options) as response:
+                        for chunk in response:
+                            if not chunk:
+                                continue
+                            if chunk.choices and chunk.choices[0].delta:
+                                text.append(chunk.choices[0].delta.content)
+                                if self.show_response and not is_quiet() and not is_only_final_output():
+                                    if status._live.is_started and chunk:
+                                        status.stop()
+                                    console_print(text[-1], end='')
+                        if self.show_response and not is_quiet() and not is_only_final_output():
+                            console_print()
+                else:
+                    # Non-streaming mode
+                    response = self.client.chat.completions.create(**options)
+                    output = response.choices[0].message.content
+                    if self.show_response and not is_quiet() and not is_only_final_output():
+                        if not is_quiet() and not is_only_final_output():
+                            status.stop()
+                        console_print()
+                    text.append(output)
+
+            return ''.join(text).strip()
         except Exception as e:
             if "rate_limit" in str(e).lower():
                 raise click.ClickException("Rate limit exceeded. Please try again later.")


### PR DESCRIPTION
1. **Enhanced LLM Support**:  
   - Clarified that `STDIN` refers to specific CLI tools (e.g., `q chat`, `mlx_lm.generate`).  
   - Added examples for configuring providers like **Amazon Q Chat** and **MLX LM** in `README.md`.  

2. **Prompt Structure Improvements**:  
   - Modified the `plain` provider mode in `init_cmd.py` to include conditional instructions in prompts (e.g., `{{ instructions }}` followed by `{{ input }}`).  

3. **Streaming Response Handling for OpenAI API Provider**:  
   - Enhanced `openai_provider.py` to support streaming responses with progress feedback (spinner) and proper output formatting.  

4. **Fix Template parsing issue**:  
   - Removed the `conditional_expression_only=True` flag in `engine.py`, enabling more flexible Jinja template rendering.