### PR TITLE
refactor engine.py, split into smaller files

### DIFF
--- a/prich/cli/dynamic_command_group.py
+++ b/prich/cli/dynamic_command_group.py
@@ -1,8 +1,10 @@
 import click
+from prich.constants import RESERVED_RUN_TEMPLATE_CLI_OPTIONS
+from prich.models.template import TemplateModel
 from prich.core.loaders import load_global_config, load_local_config, load_merged_config, load_templates
-from prich.core.engine import create_dynamic_command
+from prich.core.engine import run_template
 from prich.core.state import _loaded_templates
-from prich.core.utils import should_use_global_only, should_use_local_only
+from prich.core.utils import should_use_global_only, should_use_local_only, is_verbose, console_print
 
 
 class DynamicCommandGroup(click.Group):
@@ -32,3 +34,65 @@ class DynamicCommandGroup(click.Group):
             raise click.ClickException(f"Failed to load dynamic parameters: {e}")
 
         self._commands_loaded = True
+
+
+def get_variable_type(variable_type: str) -> click.types:
+    type_mapping = {"str": click.STRING, "int": click.INT, "bool": click.BOOL, "path": click.Path}
+    return type_mapping.get(variable_type.lower(), None)
+
+
+def create_dynamic_command(config, template: TemplateModel) -> click.Command:
+    options = []
+    for arg in template.variables if template.variables else []:
+        arg_name = arg.name
+        arg_type = get_variable_type(arg.type)
+        help_text = arg.description or f"{arg_name} option"
+        cli_option = arg.cli_option or f"--{arg_name}"
+        if cli_option in RESERVED_RUN_TEMPLATE_CLI_OPTIONS:
+            raise click.ClickException(f"{arg_name} cli option uses a reserved option name: {cli_option}")
+
+        if arg_type == click.BOOL:
+            options.append(click.Option([cli_option], is_flag=True, default=arg.default or False, show_default=True,
+                                        help=help_text))
+        elif arg_type:
+            options.append(
+                click.Option([cli_option], type=arg_type, default=arg.default, required=arg.required, show_default=True,
+                             help=help_text))
+        elif arg.type.startswith("list["):
+            list_type = get_variable_type(arg.type.split('[')[1][:-1])
+            if not list_type:
+                raise click.ClickException(f"Failed to parse list type for {arg.name}")
+            options.append(
+                click.Option([cli_option], type=list_type, multiple=True, default=arg.default, required=arg.required,
+                             show_default=True, help=help_text))
+        else:
+            raise click.ClickException(f"Unsupported variable type: {arg.type}")
+
+    options.extend([
+        click.Option(["-g", "--global", "global_only"], is_flag=True, default=False,
+                     help="Use global config and template"),
+        click.Option(["-l", "--local", "local_only"], is_flag=True, default=False,
+                     help="Use local config and template"),
+        click.Option(["-o", "--output"], type=click.Path(), default=None, show_default=True,
+                     help="Save final output to file"),
+        click.Option(["-p", "--provider"], type=click.Choice(config.providers.keys()), show_default=True,
+                     help="Override LLM provider"),
+        click.Option(["-v", "--verbose"], is_flag=True, default=False, help="Verbose mode"),
+        click.Option(["-q", "--quiet"], is_flag=True, default=False, help="Suppress all output"),
+        click.Option(["-f", "--only-final-output"], is_flag=True, default=False,
+                     help="Suppress output and show only the last step output")
+    ])
+
+    @click.pass_context
+    def dynamic_command(ctx, **kwargs):
+        if is_verbose():
+            console_print(
+                f"[dim]Template: [green]{template.name}[/green] ({template.version}), {template.source.value}, args: {', '.join([f'{k}={v}' for k, v in kwargs.items() if v])}[/dim]")
+            console_print(f"[dim]{template.description}[/dim]")
+        else:
+            console_print(f"[dim][green]{template.name}[/green] ({template.version}), {template.source.value}[/dim]")
+        run_template(template.id, **kwargs)
+
+    return click.Command(name=template.id, callback=dynamic_command, params=options,
+                         help=f"{template.description if template.description else ''}",
+                         epilog=f"{template.name} (ver: {template.version}, {template.source.value})")

--- a/prich/cli/init_cmd.py
+++ b/prich/cli/init_cmd.py
@@ -4,13 +4,14 @@ import sys
 import subprocess
 import venv
 import click
+from prich.constants import PRICH_DIR_NAME
 from prich.core.utils import console_print, get_prich_dir
 from prich.models.config_providers import EchoProviderModel
 from prich.models.config import SettingsConfig, ConfigModel, ProviderModeModel
 
 
 @click.command()
-@click.option("-g", "--global", "global_init", is_flag=True, help="Initialize ~/.prich/ (global)")
+@click.option("-g", "--global", "global_init", is_flag=True, help=f"Initialize ~/{PRICH_DIR_NAME}/ (global)")
 @click.option("--force", is_flag=True, help="Overwrite existing config")
 def init(global_init: bool, force: bool):
     """Initialize prich configuration and default venv."""
@@ -24,10 +25,10 @@ def init(global_init: bool, force: bool):
     default_venv = prich_dir / "venv"
     if force:
         # for safety, ensure that we remove only related folder
-        if ".prich" in str(default_venv):
+        if PRICH_DIR_NAME in str(default_venv):
             shutil.rmtree(default_venv, ignore_errors=True)
         else:
-            raise click.ClickException(".prich folder is not part of venv folder path")
+            raise click.ClickException(f"{PRICH_DIR_NAME} folder is not part of venv folder path")
     if not default_venv.exists():
         builder = venv.EnvBuilder(with_pip=True)
         builder.create(default_venv)
@@ -49,7 +50,8 @@ def init(global_init: bool, force: bool):
         },
         provider_modes=[
             ProviderModeModel(name="plain", prompt="{% if instructions %}{{ instructions }}\n{% endif %}{{ input }}"),
-            ProviderModeModel(name="flat", prompt="""{% if instructions %}### System:\n{{ instructions }}\n\n{% endif %}### User:\n{{ input }}\n\n### Assistant:"""),
+            ProviderModeModel(name="flat",
+                              prompt="{% if instructions %}### System:\n{{ instructions }}\n\n{% endif %}### User:\n{{ input }}\n\n### Assistant:"),
             # ProviderModeModel(name="mistral-instruct", prompt="""<s>[INST]\n{% if instructions %}{{ instructions }}\n\n{% endif %}{{ input }}\n[/INST]"""),
             # ProviderModeModel(name="llama2-chat", prompt="""<s>[INST]\n{% if instructions %}{{ instructions }}\n\n{% endif %}{{ input }}\n[/INST]"""),
             # ProviderModeModel(name="anthropic", prompt="""Human: {% if instructions %}{{ instructions }}\n\n{% endif %}{{ input }}\n\nAssistant:"""),

--- a/prich/cli/templates.py
+++ b/prich/cli/templates.py
@@ -7,6 +7,7 @@ import subprocess
 from pathlib import Path
 import click
 
+from prich.constants import PRICH_DIR_NAME
 from prich.core.loaders import get_loaded_templates, get_loaded_config, get_loaded_template
 from prich.core.utils import console_print, is_valid_template_id, get_prich_dir, get_prich_templates_dir, shorten_path
 from prich.cli.venv_utils import install_template_python_dependencies
@@ -63,7 +64,7 @@ def check_if_dest_present(template_id: str, dest_folder: Path, global_install: b
 @click.argument("path")
 @click.option("--force", is_flag=True, help="Overwrite existing templates")
 @click.option("--no-venv", is_flag=True, help="Skip venv setup")
-@click.option("-g", "--global", "global_install", is_flag=True, help="Install to ~/.prich/templates")
+@click.option("-g", "--global", "global_install", is_flag=True, help=f"Install to ~/{PRICH_DIR_NAME}/templates")
 @click.option("-r", "--remote", "from_remote", is_flag=True, help="Install template from prich-templates GitHub repo or zip URL")
 def template_install(path: str, force: bool, no_venv: bool, global_install: bool, from_remote: bool):
     """Install a template from PATH, zip, or prich-templates."""

--- a/prich/cli/validate.py
+++ b/prich/cli/validate.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 import click
+from prich.constants import PRICH_DIR_NAME
 from prich.models.template import CommandStep, PythonStep
 from prich.core.file_scope import classify_path
 from prich.core.loaders import find_template_files, load_template_model, get_env_vars
@@ -19,7 +20,7 @@ def validate_templates(template_id: str, validate_file: Path, global_only: bool,
         raise click.ClickException("Use only one local or global option, use: 'prich validate -g' or 'prich validate -l'")
 
     if validate_file and (global_only or local_only or template_id):
-        raise click.ClickException("When YAML file is selected it doesn't combine with local, global, or id options, use: 'prich validate --file ./.prich/templates/test-template/test-template.yaml'")
+        raise click.ClickException(f"When YAML file is selected it doesn't combine with local, global, or id options, use: 'prich validate --file ./{PRICH_DIR_NAME}/templates/test-template/test-template.yaml'")
 
     if validate_file and not validate_file.exists():
         raise click.ClickException(f"Failed to find {validate_file} template file.")

--- a/prich/cli/venv_utils.py
+++ b/prich/cli/venv_utils.py
@@ -5,16 +5,17 @@ from pathlib import Path
 
 import click
 
+from prich.constants import PRICH_DIR_NAME
 from prich.core.utils import shorten_path, console_print
 
 
 def install_python_venv(venv_folder: Path, force: bool = False, venv_type: str = ""):
     if venv_folder.exists() and force:
-        if ".prich" in str(venv_folder):
+        if PRICH_DIR_NAME in str(venv_folder):
             console_print(f"Removing existing {venv_type} venv folder...", end="")
             shutil.rmtree(venv_folder)
         else:
-            raise click.ClickException(".prich folder is not part of venv folder path")
+            raise click.ClickException(f"{PRICH_DIR_NAME} folder is not part of venv folder path")
         console_print(" [green]done![/green]")
     elif venv_folder.exists():
         console_print("Venv folder found.")

--- a/prich/constants.py
+++ b/prich/constants.py
@@ -4,3 +4,6 @@ RESERVED_RUN_TEMPLATE_CLI_OPTIONS = [
     "-g", "--global", "-q", "--quiet", "-o", "--output", "-p", "--provider",
     "-f", "--only-final-output", "-v", "--verbose"
 ]
+
+# .prich folder name
+PRICH_DIR_NAME = ".prich"

--- a/prich/core/file_scope.py
+++ b/prich/core/file_scope.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 
+from prich.constants import PRICH_DIR_NAME
 from prich.models.file_scope import FileScope
 
 
@@ -36,9 +37,9 @@ def _is_under(path: Path, root: Path) -> bool:
 # TODO: See if such support is really needed, could become hard to relate what is where
 # def find_nearest_local_root(start: Path, home: Path) -> Path | None:
 #     cur = start.resolve()
-#     global = home / ".prich"
+#     global = home / PRICH_DIR_NAME
 #     for p in [cur, *cur.parents]:
-#         candidate = p / ".prich"
+#         candidate = p / PRICH_DIR_NAME
 #         if candidate.exists() and candidate != global:
 #             return candidate
 #     return None
@@ -60,8 +61,8 @@ def classify_path(
     cwd = cwd or Path.cwd()
     home = home or Path.home()
 
-    local_root = cwd / ".prich"
-    global_root = home / ".prich"
+    local_root = cwd / PRICH_DIR_NAME
+    global_root = home / PRICH_DIR_NAME
 
     if follow_symlinks:
         p = _normalize(file, cwd=cwd)

--- a/prich/core/loaders.py
+++ b/prich/core/loaders.py
@@ -3,6 +3,7 @@ import os
 import click
 from pathlib import Path
 from typing import Dict, Optional, Tuple, List, Iterable
+from prich.constants import PRICH_DIR_NAME
 from prich.core.file_scope import classify_path
 from prich.core.state import _loaded_templates, _loaded_config, _loaded_config_paths
 from prich.core.utils import console_print, shorten_path, get_prich_dir
@@ -94,7 +95,7 @@ def load_template_model(yaml_file: Path) -> TemplateModel | None:
 def find_template_files(base_dir: Path) -> List[Path]:
     """Find template YAML files"""
     template_files = []
-    template_dir = base_dir / ".prich/templates"
+    template_dir = base_dir / PRICH_DIR_NAME / "templates"
     if template_dir.exists():
         for subdir in template_dir.iterdir():
             if subdir.is_dir():

--- a/prich/core/state.py
+++ b/prich/core/state.py
@@ -7,8 +7,9 @@ from prich.models.template import TemplateModel
 _loaded_config: Optional[ConfigModel] = None
 _loaded_config_paths: list[Path] = []
 _loaded_env_vars: Optional[dict[str, str]] = None
+_jinja_env = {}
 
 # Shared loaded templates cache
 _loaded_templates: dict[str, TemplateModel] = {}
 
-__all__ = ["_loaded_config", "_loaded_config_paths", "_loaded_templates", "_loaded_env_vars"]
+__all__ = ["_loaded_config", "_loaded_config_paths", "_loaded_templates", "_loaded_env_vars", "_jinja_env"]

--- a/prich/core/steps/step_render_template.py
+++ b/prich/core/steps/step_render_template.py
@@ -1,0 +1,15 @@
+from typing import Dict
+
+from prich.models.template import RenderStep
+from prich.core.utils import is_verbose, console_print
+from prich.core.template_utils import render_template_text
+
+
+def render_template(step: RenderStep, variables: dict = Dict[str, str]) -> str:
+    if is_verbose():
+        console_print("[dim]Render template:[/dim]")
+        console_print(step.template, markup=False)
+        console_print()
+        console_print("[dim]Result:[/dim]")
+    rendered_text = render_template_text(step.template, variables, "params")
+    return rendered_text

--- a/prich/core/steps/step_run_command.py
+++ b/prich/core/steps/step_run_command.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+from typing import Dict, Tuple
+
+import click
+from prich.core.loaders import get_env_vars
+from prich.core.utils import get_prich_dir, is_just_filename, is_verbose, console_print, is_quiet, is_only_final_output
+from prich.models.template import TemplateModel, PythonStep, CommandStep
+from prich.core.variable_utils import expand_vars
+
+
+def run_command_step(template: TemplateModel, step: PythonStep | CommandStep, variables: Dict[str, any]) -> Tuple[str, int]:
+    import subprocess
+    from rich.console import Console
+    console = Console()
+
+    method = step.call
+    try:
+        template_dir = Path(template.folder)
+    except Exception as e:
+        raise click.ClickException(f"Template folder was not detected properly: {e}")
+
+    if type(step) == PythonStep and step.type == "python":
+        method_path = template_dir / "scripts" / method
+        if not method_path.exists():
+            raise click.ClickException(f"Python script not found: {method_path}")
+        if not method.endswith(".py"):
+            raise click.ClickException(f"Python script file should end with .py: {method_path}")
+
+        if template.venv in ["shared", "isolated"]:
+            if template.venv == "shared":
+                venv_path = get_prich_dir() / "venv"
+            else:
+                venv_path = template_dir / "scripts" / "venv"
+            python_path = venv_path / "bin" / "python"
+            if not python_path.exists():
+                raise click.ClickException(f"{template.venv.capitalize()} venv python not found: {python_path}")
+            cmd = [str(python_path), str(method_path)]
+        elif template.venv is None:
+            cmd = ["python", str(method_path)]
+        else:
+            raise click.ClickException(f"Python script venv {template.venv} is not supported.")
+    elif type(step) == CommandStep and step.type == "command":
+        if is_just_filename(method) and (template_dir / "scripts" / method).exists():
+            cmd = [str(template_dir / "scripts" / method)]
+        else:
+            cmd = [method]
+    else:
+        raise click.ClickException(f"Template command step type {step.type} is not supported.")
+
+    # Inputs / Variables List
+    expanded_args = expand_vars(step.args, variables=variables, env_vars=get_env_vars())
+    [cmd.append(arg) for arg in expanded_args if arg is not None and arg != ""]
+
+    try:
+        if is_verbose():
+            console_print(f"[dim]Execute {step.type} [green]{' '.join(cmd)}[/green][/dim]")
+        if not is_quiet() and not is_only_final_output():
+            with console.status("Processing..."):
+                result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, check=False, env=get_env_vars())
+        else:
+            result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, check=False, env=get_env_vars())
+        return result.stdout, result.returncode
+    except Exception as e:
+        raise click.ClickException(f"Unexpected error in {method}: {str(e)}")

--- a/prich/core/steps/step_sent_to_llm.py
+++ b/prich/core/steps/step_sent_to_llm.py
@@ -1,0 +1,83 @@
+import click
+
+from prich.core.template_utils import render_prompt, render_prompt_fields
+from prich.core.utils import is_verbose, console_print, is_quiet, is_only_final_output
+from prich.models.config import ConfigModel
+from prich.models.template import TemplateModel, LLMStep
+
+
+def send_to_llm(template: TemplateModel, step: LLMStep, provider: str, config: ConfigModel, variables: dict) -> str:
+    from prich.llm_providers.get_llm_provider import get_llm_provider
+
+    if not step.input:
+        raise click.ClickException("llm step must define at least 'input' field.")
+    # Use Provider from arg overload
+    if provider:
+        selected_provider_name = provider
+    # Use LLM Step Provider assignment from template
+    elif step.provider:
+        selected_provider_name = step.provider
+    # Use Provider to template assignment from config settings
+    elif config.settings.provider_assignments and template.id in config.settings.provider_assignments.keys():
+        selected_provider_name = config.settings.provider_assignments[template.id]
+    # Use default provider from config
+    else:
+        selected_provider_name = config.settings.default_provider
+    selected_provider = config.providers.get(selected_provider_name)
+    if not selected_provider:
+        raise click.ClickException(f"Provider {selected_provider_name} configuration not found. Check your config.yaml file.")
+    if is_verbose():
+        console_print(f"Selected LLM provider: {selected_provider_name}")
+
+    if selected_provider.mode:
+        render_prompt(config, step, variables, selected_provider.mode)
+    else:
+        render_prompt_fields(step, variables)
+    if not step.rendered_prompt and not step.rendered_input:
+        raise click.ClickException(f"Prompt is empty in step {step.name}.")
+
+    llm_provider = get_llm_provider(selected_provider_name, selected_provider)
+    if ((not step.output_console and not is_verbose()) or is_quiet()) and llm_provider.show_response:
+        # Override show response when quiet mode
+        llm_provider.show_response = False
+
+    # prompt lines
+    prompt_lines = []
+    if step.rendered_prompt:
+        prompt_lines.append(step.rendered_prompt)
+    else:
+        if step.rendered_instructions:
+            prompt_lines.append(step.rendered_instructions)
+        if step.rendered_input:
+            prompt_lines.append(step.rendered_input)
+        if step.rendered_prompt:
+            prompt_lines.append(step.rendered_prompt)
+    prompt_full = '\n'.join(prompt_lines)
+
+    if is_verbose():
+        console_print(f"[dim]Sending prompt to LLM ([green]{llm_provider.name}[/green]), {len(prompt_full)} chars[/dim]")
+        console_print(prompt_full, markup=False)
+        console_print()
+        console_print("[dim]LLM Response:[/dim]")
+    try:
+        if not is_quiet() and not is_only_final_output() and not llm_provider.show_response:
+            from rich.console import Console
+            console = Console()
+            with console.status("Thinking..."):
+                response = llm_provider.send_prompt(
+                    prompt=step.rendered_prompt,
+                    instructions=step.rendered_instructions,
+                    input_=step.rendered_input
+                )
+        else:
+            response = llm_provider.send_prompt(
+                prompt=step.rendered_prompt,
+                instructions=step.rendered_instructions,
+                input_=step.rendered_input
+            )
+        step_output = selected_provider.postprocess_output(response)
+        if (is_verbose() or step.output_console) and not llm_provider.show_response and not is_quiet():
+            console_print(step_output, markup=False)
+    except Exception as e:
+        raise click.ClickException(f"Failed to get LLM response: {str(e)}")
+    return step_output

--- a/prich/core/template_utils.py
+++ b/prich/core/template_utils.py
@@ -1,0 +1,117 @@
+from pathlib import Path
+from typing import Dict
+
+import click
+
+from prich.models.template import LLMStep
+from prich.models.config import ConfigModel
+from prich.core.state import _jinja_env
+
+
+def get_jinja_env(name: str, conditional_expression_only: bool = False):
+    from jinja2 import Environment, StrictUndefined, FileSystemLoader
+
+    def _read_file_contents(filename):
+        try:
+            cwd = Path.cwd()
+            file_path = (cwd / filename).resolve()
+            if cwd not in file_path.parents and cwd != file_path:
+                raise click.ClickException(f"File is outside the current working directory")
+            with file_path.open("r", encoding="utf-8") as f:
+                return f.read()
+        except FileNotFoundError:
+            raise click.ClickException(f"File {filename} not found")
+        except UnicodeDecodeError:
+            return click.ClickException(f"Error: File '{filename}' is not a valid text file")
+        except Exception as e:
+            raise click.ClickException(f"Error reading file '{filename}': {e}")
+
+    def include_file(filename):
+        return _read_file_contents(filename)
+
+    def include_file_with_line_numbers(filename):
+        lines = _read_file_contents(filename).split('\n')
+        return '\n'.join([f"{i+1} {line}" for i, line in enumerate(lines)])
+
+    env_name = f"{name}{'_cond' if conditional_expression_only else ''}"
+    if not _jinja_env.get(env_name):
+        if conditional_expression_only:
+            env = Environment(undefined=StrictUndefined)
+            env.filters.clear()
+        else:
+            env = Environment(
+                loader=FileSystemLoader(Path.cwd()),
+                undefined=StrictUndefined
+            )
+            env.filters['include_file'] = include_file
+            env.filters['include_file_with_line_numbers'] = include_file_with_line_numbers
+        env.filters.update({
+            "lower": str.lower,
+            "upper": str.upper,
+            "strip": str.strip,
+            "length": len,
+            "int": int,
+            "float": float,
+            "replace": lambda _old, _new, _count=None: str.replace(_old, _new, _count),
+            "split": lambda _sep, _max_split: str.split(_sep, _max_split),
+            "bool": lambda x: bool(x),
+        })
+        _jinja_env[env_name] = env
+    return _jinja_env[env_name]
+
+
+def render_template_text(template_text: str, variables: dict, jinja_env_name: str = "default"):
+    import datetime
+    import os
+    import getpass
+    import platform
+
+    if not template_text:
+        return ""
+
+    builtin = {
+        "now": datetime.datetime.now(),
+        "now_utc": datetime.datetime.now(datetime.UTC),
+        "today": datetime.datetime.today().date(),
+        "cwd": os.getcwd(),
+        "user": getpass.getuser(),
+        "hostname": platform.node(),
+    }
+    variables["builtin"] = builtin
+    try:
+        rendered_text = get_jinja_env(jinja_env_name).from_string(template_text).render(**variables).strip()
+    except Exception as e:
+        raise click.ClickException(f"Render jinja error: {str(e)}")
+    return rendered_text
+
+
+def should_run_step(when_expr: str, variables: Dict[str, any]) -> bool:
+    try:
+        if when_expr in [None, ""]:
+            return True
+        if when_expr.startswith("{{") and when_expr.endswith("}}"):
+            when_expr = when_expr[2:-2].strip()
+        template = get_jinja_env("when", conditional_expression_only=True).from_string(f"{{{{ {when_expr} }}}}")
+        rendered = template.render(variables).strip().lower()
+        return rendered in ("true", "1", "yes")
+    except Exception as e:
+        raise ValueError(f"Invalid `when` expression: {when_expr} - {str(e)}")
+
+
+def render_prompt(config: ConfigModel, llm_step: LLMStep, variables: Dict[str, str], mode: str):
+    """ Render Prompt using provider mode prompt template (used for raw prompt construction) """
+    if not llm_step.input:
+        raise click.ClickException("There should be at least an 'input' field.")
+    mode_prompt = [x for x in config.model_dump().get("provider_modes") if x.get("name")==mode]
+    if len(mode_prompt) == 0:
+        raise click.ClickException(f"Prompt mode {mode} is not found in the config.")
+    prompt_fields = render_template_text(mode_prompt[0].get("prompt"), {"instructions": llm_step.instructions, "input": llm_step.input})
+    llm_step.rendered_prompt = render_template_text(prompt_fields, variables)
+
+def render_prompt_fields(llm_step: LLMStep, variables: Dict[str, str]):
+    """ Render Prompt fields (used when provider supports prompt fields templates like system/user """
+    if not llm_step.input:
+        raise click.ClickException("There should be at least an 'input' field.")
+    if llm_step.instructions:
+        llm_step.rendered_instructions = render_template_text(llm_step.instructions, variables)
+    llm_step.rendered_input = render_template_text(llm_step.input, variables)

--- a/prich/core/utils.py
+++ b/prich/core/utils.py
@@ -4,6 +4,7 @@ import re
 import click
 from pathlib import Path
 from rich.console import Console
+from prich.constants import PRICH_DIR_NAME
 
 console = Console()
 
@@ -77,34 +78,11 @@ def is_cli_option_name(option_name) -> bool:
 def get_prich_dir(global_only: bool = None) -> Path:
     """ Return current prich dir path based on global_only param or should_use_global_only() """
     parent_path = Path.home() if global_only or should_use_global_only() else Path.cwd()
-    return parent_path / ".prich"
+    return parent_path / PRICH_DIR_NAME
 
 def get_prich_templates_dir(global_only: bool = None) -> Path:
     """ Return current prich templates folder path based on global_only param or should_use_global_only() """
     return get_prich_dir(global_only) / "templates"
-
-def replace_env_vars(text: str, env_vars: dict[str, str]) -> str:
-    """
-    Replace $VAR or ${VAR} in a text string with environment variable values.
-
-    Args:
-        text (str): Input string containing $VAR or ${VAR} placeholders.
-        env_vars (dict): Environments variables to use
-
-    Returns:
-        str: String with environment variables expanded, or original text if no variables found.
-    """
-    def replace_match(match):
-        """Replace $VAR or ${VAR} with the value from os.environ or empty string if not found."""
-        var_name = match.group(1) if match.group(1) else match.group(2)
-        return env_vars.get(var_name, "")
-
-    if text is None or type(text) != str:
-        return text
-
-    # Pattern for environment variables: $VAR or ${VAR}
-    env_pattern = r'\$(?:\{([^}]+)\}|([a-zA-Z_][a-zA-Z0-9_]*))'
-    return re.sub(env_pattern, replace_match, text)
 
 def shorten_path(path: str | Path) -> str:
     """ Return short path using ~/... or ./... instead of a full absolute path """

--- a/prich/core/variable_utils.py
+++ b/prich/core/variable_utils.py
@@ -1,0 +1,56 @@
+import re
+from typing import List, Dict
+
+from prich.core.template_utils import render_template_text
+
+
+def replace_env_vars(text: str, env_vars: dict[str, str]) -> str:
+    """
+    Replace $VAR or ${VAR} in a text string with environment variable values.
+
+    Args:
+        text (str): Input string containing $VAR or ${VAR} placeholders.
+        env_vars (dict): Environments variables to use
+
+    Returns:
+        str: String with environment variables expanded, or original text if no variables found.
+    """
+    def replace_match(match):
+        """Replace $VAR or ${VAR} with the value from os.environ or empty string if not found."""
+        var_name = match.group(1) if match.group(1) else match.group(2)
+        return env_vars.get(var_name, "")
+
+    if text is None or type(text) != str:
+        return text
+
+    # Pattern for environment variables: $VAR or ${VAR}
+    env_pattern = r'\$(?:\{([^}]+)\}|([a-zA-Z_][a-zA-Z0-9_]*))'
+    return re.sub(env_pattern, replace_match, text)
+
+
+def expand_vars(args: List[str], variables: Dict[str, any] = None, env_vars: Dict[str, str] = None) -> list:
+    """
+    Expand internal variables ({{VAR}}, {{ VAR }}) and environment variables ($VAR or ${VAR}) in a list of arguments.
+
+    Args:
+        args (list): List of argument strings, e.g., ["tool", "--path={{HOME_DIR}}", "--file=$FILE"].
+        variables (dict, optional): Dictionary of internal variable names to values, e.g., {"HOME_DIR": "/home/user"}.
+        env_vars (dict, optional): Dictionary of environment variables
+
+    Returns:
+        list: New list with variables expanded.
+    """
+    # Default to empty dict if no internal variables provided
+    variables = variables or {}
+    env_vars = env_vars or {}
+
+    expanded_args = []
+    for arg in args:
+        if type(arg) == str:
+            # First expand internal variables
+            arg = render_template_text(arg, variables=variables)
+            # Then expand environment variables ($VAR or ${VAR})
+            arg = replace_env_vars(arg, env_vars=env_vars)
+        expanded_args.append(arg)
+
+    return expanded_args

--- a/prich/llm_providers/openai_provider.py
+++ b/prich/llm_providers/openai_provider.py
@@ -4,7 +4,9 @@ from contextlib import nullcontext
 
 import click
 
-from prich.core.utils import replace_env_vars, console, is_quiet, is_only_final_output, console_print
+from prich.constants import PRICH_DIR_NAME
+from prich.core.utils import console, is_quiet, is_only_final_output, console_print
+from prich.core.variable_utils import replace_env_vars
 from prich.models.config_providers import OpenAIProviderModel
 from prich.llm_providers.llm_provider_interface import LLMProvider
 from prich.llm_providers.base_optional_provider import LazyOptionalProvider
@@ -75,6 +77,6 @@ class OpenAIProvider(LLMProvider, LazyOptionalProvider):
             if "rate_limit" in str(e).lower():
                 raise click.ClickException("Rate limit exceeded. Please try again later.")
             elif "authentication" in str(e).lower():
-                raise click.ClickException("Invalid API key. Check .prich/config.yaml.")
+                raise click.ClickException(f"Invalid API key. Check {PRICH_DIR_NAME}/config.yaml.")
             raise click.ClickException(f"OpenAI error: {str(e)}")
 

--- a/prich/models/config.py
+++ b/prich/models/config.py
@@ -4,6 +4,7 @@ import click
 from pathlib import Path
 from typing import List, Optional, Literal, Dict, Annotated, Union
 from pydantic import BaseModel, Field, field_validator, TypeAdapter, ConfigDict
+from prich.constants import PRICH_DIR_NAME
 from prich.models.file_scope import FileScope
 from prich.models.config_providers import EchoProviderModel, OpenAIProviderModel, MLXLocalProviderModel, STDINConsumerProviderModel, OllamaProviderModel
 from prich.version import CONFIG_SCHEMA_VERSION
@@ -75,7 +76,7 @@ class ConfigModel(BaseModel):
             base_dir = Path.home()
         else:
             raise click.ClickException("Save config location param value is not supported")
-        prich_dir = base_dir / ".prich"
+        prich_dir = base_dir / PRICH_DIR_NAME
         os.makedirs(prich_dir, exist_ok=True)
         prich_config_file = prich_dir / "config.yaml"
         if prich_config_file.exists():

--- a/prich/models/template.py
+++ b/prich/models/template.py
@@ -4,7 +4,7 @@ import click
 from pydantic import BaseModel, Field, model_validator, ConfigDict
 from typing import List, Optional, Literal, Annotated, Union
 from prich.models.output_shaping import BaseOutputShapingModel
-from prich.constants import RESERVED_RUN_TEMPLATE_CLI_OPTIONS
+from prich.constants import RESERVED_RUN_TEMPLATE_CLI_OPTIONS, PRICH_DIR_NAME
 from prich.models.file_scope import FileScope
 from prich.core.utils import is_valid_variable_name, is_cli_option_name
 from prich.version import TEMPLATE_SCHEMA_VERSION
@@ -224,9 +224,9 @@ class TemplateModel(BaseModel):
 
         prich_dir = None
         if location == "local" or (not location and self.source == FileScope.LOCAL):
-            prich_dir = Path.cwd() / ".prich"
+            prich_dir = Path.cwd() / PRICH_DIR_NAME
         elif location == "global" or (not location and self.source == FileScope.GLOBAL):
-            prich_dir = Path.home() / ".prich"
+            prich_dir = Path.home() / PRICH_DIR_NAME
         if location or (not location and self.source):
             template_file = prich_dir / "templates" / self.id / f"{self.id}.yaml"
         else:


### PR DESCRIPTION
### **1. Centralized Constants for Path Management**
- Replaced hardcoded paths like `".prich"` with a constant `PRICH_DIR_NAME` from `prich/constants.py`.

### **2. Refactored Template Rendering Logic**
- Introduced `render_template_text` in `prich/core/template_utils.py` to replace older rendering functions.

### **3. Centralized Environment Variable Handling**
- Introduced `get_env_vars()` in `prich/core/utils.py` to retrieve environment variables.

### **4. Modularization of Core Logic**
- Moved `run_command_step` to `prich/core/steps/step_run_command.py`.
- Moved `render_template` to `prich/core/steps/step_render_template.py`.
- Moved `send_to_llm` to `prich/core/steps/step_sent_to_llm.py`.

### **5. Type and Scope Management**
- Moved `create_dynamic_command` to `prich/cli/dynamic_command_group.py`.
- Updated `get_variable_type()` to use `prich/cli/dynamic_command_group.py` for dynamic command handling.