### PR TITLE
autocomplete command generation added

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ Use shared templates to ensure consistent LLM outputs, whether for code reviews 
 - **Cross-Functional Use**:
 Developers, data analysts, marketers, or support teams can use prich for their prompts, with templates tailored to each domain.
 
+## Shell Completion  
+`prich` supports autocompletion for **zsh**, **bash**, and **fish**.
+
+See [How-To Install](docs/how-to/install.md)
 
 ## Template Reference
 
@@ -211,95 +215,6 @@ variables:
     required: false
     default: null
     type: str
-```
-
-```yaml
-id: "summarize-git-diff"
-name: "Summarize git diff"
-schema_version: "1.0"
-version: "1.0"
-author: "prich"
-description: Generate a summary and review of differences between local code and remote or committed states.
-tags: ["code", "git", "diff", "review"]
-steps:
-  - name: "Run git diff working vs last commit"
-    when: "working_vs_last_commit or (not working_vs_last_commit and not working_vs_remote and not committed_vs_remote and not remote_vs_local)"
-    type: command
-    call: "git"
-    args: ["diff", "HEAD"]
-    output_variable: "git_diff"
-
-  - name: "Get current branch"
-    when: "not working_vs_last_commit"
-    type: command
-    call: "git"
-    args: ["rev-parse", "--abbrev-ref", "HEAD"]
-    output_variable: "current_branch"
-
-  - name: "Run git diff working vs remote"
-    when: "working_vs_remote"
-    type: command
-    call: "git"
-    args: ["diff", "origin/{{current_branch}}"]
-    output_variable: "git_diff"
-
-  - name: "Run git diff committed vs remote"
-    when: "committed_vs_remote"
-    type: command
-    call: "git"
-    args: ["diff", "origin/{{current_branch}}..HEAD"]
-    output_variable: "git_diff"
-
-  - name: "Run git diff remote vs local"
-    when: "remote_vs_local"
-    type: command
-    call: "git"
-    args: ["diff", "HEAD..origin/{{current_branch}}"]
-    output_variable: "git_diff"
-
-  - name: "Ask to summarize the diff"
-    type: llm
-    instructions: |
-      Assistant is a senior engineer who makes a git diff summarization{% if review %} and detailed review{% endif %} in natural language.
-    input: |
-      Summarize {% if review %} and review {% endif %}the following:
-      ```text
-      {{ git_diff }}
-      ```
-usage_examples:
-  - "summarize-git-diff"
-  - "summarize-git-diff --review"
-  - "summarize-git-diff --working-vs-last-commit"
-  - "summarize-git-diff --working-vs-last-commit --review"
-  - "summarize-git-diff --working-vs-remote"
-  - "summarize-git-diff --committed-vs-remote"
-  - "summarize-git-diff --remote-vs-local"
-variables:
-  - name: working_vs_last_commit
-    description: "Unstaged working changes"
-    cli_option: --working-vs-last-commit
-    required: false
-    type: bool
-  - name: working_vs_remote
-    description: "All uncommitted + unpushed vs remote"
-    cli_option: --working-vs-remote
-    required: false
-    type: bool
-  - name: committed_vs_remote
-    description: "Only unpushed commits"
-    cli_option: --committed-vs-remote
-    required: false
-    type: bool
-  - name: remote_vs_local
-    description: "Changes on remote not in local"
-    cli_option: --remote-vs-local
-    required: false
-    type: bool
-  - name: review
-    description: "Make deeper review additionally"
-    cli_option: --review
-    required: false
-    type: bool
 ```
 
 ## Validate Templates  

--- a/docs/how-to/install.md
+++ b/docs/how-to/install.md
@@ -41,7 +41,7 @@ pipx install git+https://github.com/oleks-dev/prich --force
 ```
 
 
-### **Initialize prich**:
+### **Initialize prich**
 **prich** uses nodejs-like home/local folder configurations for flexible usage of the configs and templates per project.  
 
    - Local folder based
@@ -56,4 +56,47 @@ pipx install git+https://github.com/oleks-dev/prich --force
        ```
      
        > Creates `~/.prich/` with a default preprocessing shared venv (`~/.prich/venv/`) and config file.
-     
+
+
+### Shell Completion  
+`prich` supports autocompletion for **zsh**, **bash**, and **fish**.
+
+#### Zsh  
+```bash
+# Option 1: One-liner (recommended)
+prich completion zsh > ~/.zfunc/_prich
+echo 'fpath=(~/.zfunc $fpath)' >> ~/.zshrc
+autoload -Uz compinit && compinit
+
+# Option 2: Source manually in ~/.zshrc
+prich completion zsh > ~/.prich-completion.zsh
+echo 'source ~/.prich-completion.zsh' >> ~/.zshrc
+```
+
+#### Bash  
+> **NOTE!**: Requires bash ≥ 4.4 (the system bash on macOS is too old,
+install `brew install bash` if needed).
+
+```bash
+# Option 1: One-liner
+prich completion bash > ~/.prich-completion.bash
+echo 'source ~/.prich-completion.bash' >> ~/.bashrc
+
+# Option 2: Generate directly inside ~/.bashrc
+echo 'eval "$(_PRICH_COMPLETE=bash_source prich)"' >> ~/.bashrc
+```
+
+#### Fish
+```bash
+# Option 1: Copy into fish completions dir
+prich completion fish > ~/.config/fish/completions/prich.fish
+
+# Option 2: Source manually from config.fish
+prich completion fish > ~/.prich-completion.fish
+echo 'source ~/.prich-completion.fish' >> ~/.config/fish/config.fish
+```
+
+After running one of the above, restart your shell and try:  
+```bash
+prich <TAB>
+```

--- a/prich/cli/init_cmd.py
+++ b/prich/cli/init_cmd.py
@@ -1,7 +1,7 @@
 import os
 import shutil
-import sys
 import subprocess
+import sys
 import venv
 import click
 from prich.constants import PRICH_DIR_NAME
@@ -62,3 +62,28 @@ def init(global_init: bool, force: bool):
     config.save("global" if global_init else "local")
 
     console_print(f"Initialized [cyan]prich[/cyan] at [green]{prich_dir}[/green]")
+
+
+@click.command(hidden=True)
+@click.argument("shell", type=click.Choice(["bash", "zsh", "fish"]))
+def completion(shell: str):
+    """
+    Generate shell completion script for BASH, ZSH, or FISH.
+
+    Example:
+      prich completion zsh > ~/.zfunc/_prich
+    """
+    env = os.environ.copy()
+    env["_PRICH_COMPLETE"] = f"{shell}_source"
+
+    try:
+        # Run this same CLI with modified environment
+        subprocess.run(
+            [sys.argv[0]],        # re-invoke current CLI script
+            env=env,
+            text=True,
+            check=True                  # raise error if prich fails
+        )
+    except subprocess.CalledProcessError as e:
+        click.echo(f"Error generating completion script: {e}", err=True)
+        sys.exit(e.returncode)

--- a/prich/cli/main.py
+++ b/prich/cli/main.py
@@ -5,7 +5,7 @@ from prich.cli.templates import template_install, show_template, create_template
 from prich.cli.listing import list_tags, list_templates
 from prich.cli.config import config_group
 from prich.cli.validate import validate_templates
-from prich.cli.init_cmd import init
+from prich.cli.init_cmd import init, completion
 from prich.core.utils import console_print
 from prich.version import VERSION
 
@@ -19,6 +19,7 @@ cli.add_command(run_group)
 cli.add_command(template_install)
 cli.add_command(config_group)
 cli.add_command(init)
+cli.add_command(completion)
 cli.add_command(list_tags)
 cli.add_command(list_templates)
 cli.add_command(show_template)


### PR DESCRIPTION
The git diff introduces **shell completion support** for `prich` and updates documentation to reflect this feature. Here's the summary:

### Key Changes:
1. **New Shell Completion Feature**  
   - Added support for **zsh**, **bash**, and **fish** autocompletion.  
   - Detailed installation instructions for each shell are included in `README.md` and `docs/how-to/install.md`, including one-liners and manual configuration steps.

2. **Documentation Updates**  
   - Removed the old `summarize-git-diff` YAML command from `README.md` (not needed here anymore).  
   - Enhanced `docs/how-to/install.md` with clear steps for enabling shell completion.

3. **Code Integration**  
   - Added a `completion` command in `prich/cli/init_cmd.py` to generate shell-specific completion scripts.  
   - Registered the `completion` command in `prich/cli/main.py` to make it accessible via the CLI.

### Summary:  
The update focuses on improving user experience by enabling shell autocompletion for `prich`, with corresponding documentation and code changes to support this feature.