### PR TITLE
fix dynamic options click path type to support properly the autocomplete

### DIFF
--- a/prich/cli/dynamic_command_group.py
+++ b/prich/cli/dynamic_command_group.py
@@ -36,8 +36,8 @@ class DynamicCommandGroup(click.Group):
         self._commands_loaded = True
 
 
-def get_variable_type(variable_type: str) -> click.types:
-    type_mapping = {"str": click.STRING, "int": click.INT, "bool": click.BOOL, "path": click.Path}
+def get_click_variable_type(variable_type: str) -> click.types:
+    type_mapping = {"str": click.STRING, "int": click.INT, "bool": click.BOOL, "path": click.Path()}
     return type_mapping.get(variable_type.lower(), None)
 
 
@@ -45,7 +45,7 @@ def create_dynamic_command(config, template: TemplateModel) -> click.Command:
     options = []
     for arg in template.variables if template.variables else []:
         arg_name = arg.name
-        arg_type = get_variable_type(arg.type)
+        arg_type = get_click_variable_type(arg.type)
         help_text = arg.description or f"{arg_name} option"
         cli_option = arg.cli_option or f"--{arg_name}"
         if cli_option in RESERVED_RUN_TEMPLATE_CLI_OPTIONS:
@@ -59,7 +59,7 @@ def create_dynamic_command(config, template: TemplateModel) -> click.Command:
                 click.Option([cli_option], type=arg_type, default=arg.default, required=arg.required, show_default=True,
                              help=help_text))
         elif arg.type.startswith("list["):
-            list_type = get_variable_type(arg.type.split('[')[1][:-1])
+            list_type = get_click_variable_type(arg.type.split('[')[1][:-1])
             if not list_type:
                 raise click.ClickException(f"Failed to parse list type for {arg.name}")
             options.append(

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -496,11 +496,11 @@ def test_render_prompt_fields():
     # assert llm_step.rendered_input == "prompt"
 
 def test_get_variable_type():
-    from prich.cli.dynamic_command_group import get_variable_type
-    assert get_variable_type("str") == click.STRING
-    assert get_variable_type("int") == click.INT
-    assert get_variable_type("bool") == click.BOOL
-    assert get_variable_type("path") == click.Path
+    from prich.cli.dynamic_command_group import get_click_variable_type
+    assert get_click_variable_type("str") == click.STRING
+    assert get_click_variable_type("int") == click.INT
+    assert get_click_variable_type("bool") == click.BOOL
+    assert type(get_click_variable_type("path")) == click.Path
 
 
 def test_create_dynamic_command(basic_config, template):


### PR DESCRIPTION
The git diff shows several key changes in the `dynamic_command_group.py` and `test_engine.py` files:

1. **Function Renaming**:  
   The function `get_variable_type` was renamed to `get_click_variable_type` to better reflect its purpose of mapping variable types to Click CLI types.

2. **Type Mapping Update**:  
   The `type_mapping` dictionary now uses `click.Path()` (instantiated) instead of just `click.Path` for the "path" type. This ensures the `Path` type is properly constructed as a Click type.

3. **Usage Updates**:  
   All calls to `get_variable_type` were replaced with `get_click_variable_type` in the `create_dynamic_command` function, including handling for list types (e.g., `list[str]`).

4. **Test Adjustments**:  
   The test `test_get_variable_type` was updated to import and use the renamed `get_click_variable_type` function, aligning with the code changes.

**Summary**:  
The changes standardize the use of Click CLI types, ensure proper instantiation of `click.Path`, and rename functions for clarity. This fixes issues with type parsing in CLI argument handling and updates tests to match the new implementation.