### PR TITLE
Main dir handling and tests

### DIFF
--- a/prich/cli/validate.py
+++ b/prich/cli/validate.py
@@ -5,7 +5,7 @@ from prich.constants import PRICH_DIR_NAME
 from prich.models.template import CommandStep, PythonStep
 from prich.core.file_scope import classify_path
 from prich.core.loaders import find_template_files, load_template_model, get_env_vars
-from prich.core.utils import console_print, shorten_path, get_prich_dir, is_just_filename
+from prich.core.utils import console_print, shorten_path, get_prich_dir, is_just_filename, get_cwd_dir, get_home_dir
 
 
 @click.command(name="validate")
@@ -32,11 +32,11 @@ def validate_templates(template_id: str, validate_file: Path, global_only: bool,
         template_files = [validate_file]
     else:
         # Prepare Template Files Path
-        file_paths = [Path.cwd(), Path.home()]
+        file_paths = [get_cwd_dir(), get_home_dir()]
         if global_only:
-            file_paths.remove(Path.cwd())
+            file_paths.remove(get_cwd_dir())
         if local_only:
-            file_paths.remove(Path.home())
+            file_paths.remove(get_home_dir())
         for base_dir in file_paths:
             template_files.extend(find_template_files(base_dir))
 

--- a/prich/core/engine.py
+++ b/prich/core/engine.py
@@ -1,5 +1,4 @@
 import click
-from pathlib import Path
 from typing import Dict
 
 from prich.core.template_utils import should_run_step
@@ -10,7 +9,7 @@ from prich.core.steps.step_sent_to_llm import send_to_llm
 from prich.models.template import LLMStep, PythonStep, RenderStep, \
     CommandStep, ValidateStepOutput
 from prich.core.utils import console_print, is_quiet, is_only_final_output, \
-    is_verbose
+    is_verbose, get_cwd_dir, get_home_dir
 from prich.core.loaders import get_env_vars
 from prich.core.variable_utils import replace_env_vars, expand_vars
 
@@ -120,9 +119,9 @@ def run_template(template_id, **kwargs):
                 variables[output_var] = step_output
             if step.output_file:
                 if step.output_file.startswith('.'):
-                    save_to_file = step.output_file.replace('.', str(Path.cwd()), 1)
+                    save_to_file = step.output_file.replace('.', str(get_cwd_dir()), 1)
                 elif step.output_file.startswith('~'):
-                    save_to_file = step.output_file.replace('~', str(Path.home()), 1)
+                    save_to_file = step.output_file.replace('~', str(get_home_dir()), 1)
                 else:
                     save_to_file = step.output_file
                 try:

--- a/prich/core/file_scope.py
+++ b/prich/core/file_scope.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 
+from prich.core.utils import get_cwd_dir, get_home_dir
 from prich.constants import PRICH_DIR_NAME
 from prich.models.file_scope import FileScope
 
@@ -58,8 +59,8 @@ def classify_path(
     - Global live in <home>/.prich
     - Returns EXTERNAL if neither matches.
     """
-    cwd = cwd or Path.cwd()
-    home = home or Path.home()
+    cwd = cwd or get_cwd_dir()
+    home = home or get_home_dir()
 
     local_root = cwd / PRICH_DIR_NAME
     global_root = home / PRICH_DIR_NAME

--- a/prich/core/loaders.py
+++ b/prich/core/loaders.py
@@ -6,7 +6,7 @@ from typing import Dict, Optional, Tuple, List, Iterable
 from prich.constants import PRICH_DIR_NAME
 from prich.core.file_scope import classify_path
 from prich.core.state import _loaded_templates, _loaded_config, _loaded_config_paths
-from prich.core.utils import console_print, shorten_path, get_prich_dir
+from prich.core.utils import console_print, shorten_path, get_prich_dir, get_cwd_dir, get_home_dir
 from prich.models.utils import recursive_update
 from prich.models.config import ConfigModel
 from prich.models.template import TemplateModel
@@ -119,10 +119,10 @@ def _load_template_models(base_dir: Path) -> List[TemplateModel]:
 def load_templates() -> List[TemplateModel]:
     """Load templates based on the global+local or only local or only global"""
     from prich.core.utils import should_use_global_only, should_use_local_only
-    global_templates = _load_template_models(Path.home())
+    global_templates = _load_template_models(get_home_dir())
     if should_use_global_only():
         return global_templates
-    local_templates = _load_template_models(Path.cwd())
+    local_templates = _load_template_models(get_cwd_dir())
     if should_use_local_only():
         return local_templates
     local_ids = {template.id for template in local_templates if template}

--- a/prich/core/template_utils.py
+++ b/prich/core/template_utils.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import Dict
 
 import click
@@ -6,6 +5,7 @@ import click
 from prich.models.template import LLMStep
 from prich.models.config import ConfigModel
 from prich.core.state import _jinja_env
+from prich.core.utils import get_cwd_dir
 
 
 def get_jinja_env(name: str, conditional_expression_only: bool = False):
@@ -13,7 +13,7 @@ def get_jinja_env(name: str, conditional_expression_only: bool = False):
 
     def _read_file_contents(filename):
         try:
-            cwd = Path.cwd()
+            cwd = get_cwd_dir()
             file_path = (cwd / filename).resolve()
             if cwd not in file_path.parents and cwd != file_path:
                 raise click.ClickException(f"File is outside the current working directory")
@@ -40,7 +40,7 @@ def get_jinja_env(name: str, conditional_expression_only: bool = False):
             env.filters.clear()
         else:
             env = Environment(
-                loader=FileSystemLoader(Path.cwd()),
+                loader=FileSystemLoader(get_cwd_dir()),
                 undefined=StrictUndefined
             )
             env.filters['include_file'] = include_file

--- a/prich/core/utils.py
+++ b/prich/core/utils.py
@@ -81,10 +81,24 @@ def is_cli_option_name(option_name) -> bool:
     pattern = r'^--[a-z0-9]+([-_a-z0-9]+)*$'
     return bool(re.match(pattern, option_name))
 
-def get_cwd_dir():
+def get_cwd_dir() -> Path:
+    """Return current directory, prefer $PWD if set (symlink-preserving)."""
+    pwd = os.environ.get("PWD")
+    if pwd:
+        try:
+            return Path(pwd)
+        except Exception:
+            pass
     return Path.cwd()
 
-def get_home_dir():
+def get_home_dir() -> Path:
+    """Return home directory, prefer $HOME if set (common CLI convention)."""
+    home = os.environ.get("HOME")
+    if home:
+        try:
+            return Path(home)
+        except Exception:
+            pass
     return Path.home()
 
 def get_prich_dir(global_only: bool = None) -> Path:

--- a/prich/core/utils.py
+++ b/prich/core/utils.py
@@ -17,39 +17,45 @@ def should_use_global_only() -> bool:
                 return True
     except:
         pass
-    return any(flag in sys.argv for flag in ("-g", "--global"))
+    return False
 
 def should_use_local_only() -> bool:
     """ Should only local config/templates used? """
     try:
-        local_only_options = ["local_only"]
-        for global_ in local_only_options:
-            if click.get_current_context().params.get(global_):
-                return True
+        if click.get_current_context().params.get("local_only"):
+            return True
     except:
         pass
-    return any(flag in sys.argv for flag in ("-l", "--local"))
+    return False
 
 def is_verbose() -> bool:
     """ Is Verbose mode enabled? """
     try:
-        is_verbose_options = ["verbose"]
-        for verbose_ in is_verbose_options:
-            if click.get_current_context().params.get(verbose_):
-                return True
+        if click.get_current_context().params.get("verbose"):
+            return True
     except:
         pass
-    return any(flag in sys.argv for flag in ("-v", "--verbose"))
+    return False
 
 def is_quiet() -> bool:
     """ Is Quiet mode enabled? """
-    return any(flag in sys.argv for flag in ("-q", "--quiet"))
+    try:
+        if click.get_current_context().params.get("quiet"):
+            return True
+    except:
+        pass
+    return False
 
 def is_only_final_output() -> bool:
     """ Show only output of the last step? """
     if is_piped():
         return True
-    return any(flag in sys.argv for flag in ("-f", "--only-final-output"))
+    try:
+        if click.get_current_context().params.get("only_final_output"):
+            return True
+    except:
+        pass
+    return False
 
 def is_piped() -> bool:
     """ Check if prich executed with a piped command (should work only when not executed from pytest) """
@@ -75,9 +81,15 @@ def is_cli_option_name(option_name) -> bool:
     pattern = r'^--[a-z0-9]+([-_a-z0-9]+)*$'
     return bool(re.match(pattern, option_name))
 
+def get_cwd_dir():
+    return Path.cwd()
+
+def get_home_dir():
+    return Path.home()
+
 def get_prich_dir(global_only: bool = None) -> Path:
     """ Return current prich dir path based on global_only param or should_use_global_only() """
-    parent_path = Path.home() if global_only or should_use_global_only() else Path.cwd()
+    parent_path = get_home_dir() if global_only or should_use_global_only() else get_cwd_dir()
     return parent_path / PRICH_DIR_NAME
 
 def get_prich_templates_dir(global_only: bool = None) -> Path:
@@ -87,7 +99,7 @@ def get_prich_templates_dir(global_only: bool = None) -> Path:
 def shorten_path(path: str | Path) -> str:
     """ Return short path using ~/... or ./... instead of a full absolute path """
     home = str(Path.home())
-    cwd = str(Path.cwd())
+    cwd = str(get_cwd_dir())
     if type(path) == Path:
         path = str(path)
     if path.startswith(home):

--- a/prich/models/config.py
+++ b/prich/models/config.py
@@ -1,10 +1,10 @@
 import os
 
 import click
-from pathlib import Path
 from typing import List, Optional, Literal, Dict, Annotated, Union
 from pydantic import BaseModel, Field, field_validator, TypeAdapter, ConfigDict
 from prich.constants import PRICH_DIR_NAME
+from prich.core.utils import get_cwd_dir, get_home_dir
 from prich.models.file_scope import FileScope
 from prich.models.config_providers import EchoProviderModel, OpenAIProviderModel, MLXLocalProviderModel, STDINConsumerProviderModel, OllamaProviderModel
 from prich.version import CONFIG_SCHEMA_VERSION
@@ -71,9 +71,9 @@ class ConfigModel(BaseModel):
         yaml.add_representer(str, str_presenter, Dumper=yaml.SafeDumper)
 
         if location == FileScope.LOCAL:
-            base_dir = Path.cwd()
+            base_dir = get_cwd_dir()
         elif location == FileScope.GLOBAL:
-            base_dir = Path.home()
+            base_dir = get_home_dir()
         else:
             raise click.ClickException("Save config location param value is not supported")
         prich_dir = base_dir / PRICH_DIR_NAME

--- a/prich/models/config.py
+++ b/prich/models/config.py
@@ -28,7 +28,7 @@ class SecurityConfig(BaseModel):
 
 class SettingsConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
-    default_provider: str
+    default_provider: Optional[str] = None
     provider_assignments: Optional[Dict[str, str]] = None
     editor: Optional[str] = None
     env_file: Optional[str | List[str]] = None
@@ -44,7 +44,7 @@ class ConfigModel(BaseModel):
     schema_version: Literal["1.0"] = CONFIG_SCHEMA_VERSION
     providers: Dict[str, ProviderConfig]
     provider_modes: List[ProviderModeModel]
-    settings: SettingsConfig
+    settings: Optional[SettingsConfig] = None
     security: Optional[SecurityConfig] = None
 
     @classmethod

--- a/prich/models/template.py
+++ b/prich/models/template.py
@@ -4,9 +4,9 @@ import click
 from pydantic import BaseModel, Field, model_validator, ConfigDict
 from typing import List, Optional, Literal, Annotated, Union
 from prich.models.output_shaping import BaseOutputShapingModel
-from prich.constants import RESERVED_RUN_TEMPLATE_CLI_OPTIONS, PRICH_DIR_NAME
+from prich.constants import RESERVED_RUN_TEMPLATE_CLI_OPTIONS
 from prich.models.file_scope import FileScope
-from prich.core.utils import is_valid_variable_name, is_cli_option_name
+from prich.core.utils import is_valid_variable_name, is_cli_option_name, get_prich_dir
 from prich.version import TEMPLATE_SCHEMA_VERSION
 
 
@@ -224,9 +224,9 @@ class TemplateModel(BaseModel):
 
         prich_dir = None
         if location == "local" or (not location and self.source == FileScope.LOCAL):
-            prich_dir = Path.cwd() / PRICH_DIR_NAME
+            prich_dir = get_prich_dir(global_only=False)
         elif location == "global" or (not location and self.source == FileScope.GLOBAL):
-            prich_dir = Path.home() / PRICH_DIR_NAME
+            prich_dir = get_prich_dir(global_only=True)
         if location or (not location and self.source):
             template_file = prich_dir / "templates" / self.id / f"{self.id}.yaml"
         else:

--- a/tests/fixtures/paths.py
+++ b/tests/fixtures/paths.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
@@ -36,6 +37,8 @@ def mock_paths(tmp_path, monkeypatch):
     monkeypatch.setattr(Path, "cwd", lambda: cwd_dir)
     config.save(FileScope.GLOBAL)
     config.save(FileScope.LOCAL)
+    os.environ['HOME'] = str(home_dir)
+    os.environ['PWD'] = str(cwd_dir)
 
     @dataclass
     class PrichFolder:

--- a/tests/fixtures/templates.py
+++ b/tests/fixtures/templates.py
@@ -71,6 +71,12 @@ def template(tmp_path):
                 type="str",
                 default="Assistant",
                 required=False
+            ),
+            VariableDefinition(
+                name="test_output",
+                type="str",
+                default="This is my text",
+                required=False
             )
         ],
         steps=[

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -13,6 +13,7 @@ from prich.core.loaders import load_config_model, get_env_vars
 from prich.core.template_utils import render_prompt, render_template_text
 from tests.fixtures.config import basic_config, basic_config_with_prompts, CONFIG_YAML
 from tests.fixtures.templates import template
+from tests.fixtures.paths import mock_paths
 from tests.generate.templates import generate_template
 
 variables = {
@@ -263,7 +264,7 @@ get_get_jinja_env_CASES = [
      },
 ]
 @pytest.mark.parametrize("case", get_get_jinja_env_CASES, ids=[c["id"] for c in get_get_jinja_env_CASES])
-def test_get_jinja_env(tmp_path, case):
+def test_get_jinja_env(mock_paths, case):
     from prich.core.template_utils import get_jinja_env
     jinja_env = get_jinja_env("test_env", case.get("conditional_expression_only"))
     assert jinja_env, "Jinja env is not initialized"
@@ -387,8 +388,14 @@ get_validate_step_output_CASES = [
      },
 ]
 @pytest.mark.parametrize("case", get_validate_step_output_CASES, ids=[c["id"] for c in get_validate_step_output_CASES])
-def test_validate_step_output(case):
+def test_validate_step_output(mock_paths, basic_config, case):
     from prich.core.engine import validate_step_output
+
+    local_config = basic_config.model_copy(deep=True)
+    global_config = basic_config.model_copy(deep=True)
+    local_config.save("local")
+    global_config.save("global")
+
     if case.get("expected_exception"):
         with pytest.raises(case.get("expected_exception")):
             validate_step_output(case.get("step_validation"), case.get("value", {}), {})

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+from subprocess import CompletedProcess
+
 import pytest
 from click.testing import CliRunner
 
@@ -45,3 +47,15 @@ def test_init_cmd(tmp_path, monkeypatch, case):
         if case.get("expected_output_2") is not None:
             result = runner.invoke(init, case.get("args_2"))
             assert case.get("expected_output_2") in result.output
+
+
+def test_completion_cmd(tmp_path, monkeypatch):
+    from prich.cli.init_cmd import completion
+
+    monkeypatch.setattr("subprocess.run", lambda cmd, env, text, check: CompletedProcess(args=[], returncode=0, stdout="output"))
+
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        runner.invoke(completion, ["bash"])
+        runner.invoke(completion, ["zsh"])
+        runner.invoke(completion, ["fish"])

--- a/tests/test_listing.py
+++ b/tests/test_listing.py
@@ -2,6 +2,7 @@ import pytest
 from click.testing import CliRunner
 
 from tests.generate.templates import templates, templates_list_to_dict
+from tests.fixtures.paths import mock_paths
 
 get_list_tags_CASES = [
     {"id": "local", "count": 4, "args": ["-l"],
@@ -16,7 +17,7 @@ get_list_tags_CASES = [
      "expected_output": "Use only one local or global option, use"},
 ]
 @pytest.mark.parametrize("case", get_list_tags_CASES, ids=[c["id"] for c in get_list_tags_CASES])
-def test_list_tags(tmp_path, monkeypatch, case):
+def test_list_tags(mock_paths, monkeypatch, case):
     from prich.cli.listing import list_tags
     from prich.core.state import _loaded_templates
     _loaded_templates.clear()
@@ -35,7 +36,7 @@ def test_list_tags(tmp_path, monkeypatch, case):
     _loaded_templates.update(template_dict)
 
     runner = CliRunner()
-    with runner.isolated_filesystem(temp_dir=tmp_path):
+    with runner.isolated_filesystem(temp_dir=mock_paths.home_dir):
         result = runner.invoke(list_tags, case.get("args"))
         if case.get("expected_output") is not None:
             assert case.get("expected_output") in result.output
@@ -69,7 +70,7 @@ get_list_templates_CASES = [
      "expected_output": "{\n", "check_count": False},
 ]
 @pytest.mark.parametrize("case", get_list_templates_CASES, ids=[c["id"] for c in get_list_templates_CASES])
-def test_list_templates(tmp_path, monkeypatch, case):
+def test_list_templates(mock_paths, monkeypatch, case):
     from prich.cli.listing import list_templates
     from prich.core.state import _loaded_templates
     _loaded_templates.clear()
@@ -78,7 +79,7 @@ def test_list_templates(tmp_path, monkeypatch, case):
     monkeypatch.setattr("prich.core.loaders.load_templates", lambda: template_list)
 
     runner = CliRunner()
-    with runner.isolated_filesystem(temp_dir=tmp_path):
+    with runner.isolated_filesystem(temp_dir=mock_paths.home_dir):
         result = runner.invoke(list_templates, case.get("args"))
         if case.get("expected_output") is not None:
             assert case.get("expected_output") in result.output

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 import click
@@ -8,6 +7,7 @@ from prich.models.file_scope import FileScope
 from prich.models.template import TemplateModel, PythonStep
 from prich.models.template_repo_manifest import TemplatesRepoManifest
 from tests.fixtures.config import basic_config
+from tests.fixtures.paths import mock_paths
 
 def test_model_template_repo_manifest():
     test_repo = {
@@ -362,7 +362,7 @@ get_model_template_save_CASES = [
    },
 ]
 @pytest.mark.parametrize("case", get_model_template_save_CASES, ids=[c["id"] for c in get_model_template_save_CASES])
-def test_model_template_save(monkeypatch, tmp_path, case):
+def test_model_template_save(monkeypatch, mock_paths, case):
     template = TemplateModel(
         id="test-tpl",
         name="Test TPL",
@@ -380,10 +380,8 @@ def test_model_template_save(monkeypatch, tmp_path, case):
     for k, v in case.get("template").items():
         template.__setattr__(k, v)
 
-    global_dir = tmp_path / "home"
-    local_dir = tmp_path / "local"
-    global_dir.mkdir()
-    local_dir.mkdir()
+    global_dir = mock_paths.home_dir
+    local_dir = mock_paths.cwd_dir
     monkeypatch.setattr(Path, "home", lambda: global_dir)
     monkeypatch.setattr(Path, "cwd", lambda: local_dir)
     if case.get("expected_exception"):
@@ -407,11 +405,9 @@ get_model_config_CASES = [
   {"id": "save_global", "location": FileScope.GLOBAL},
 ]
 @pytest.mark.parametrize("case", get_model_config_CASES, ids=[c["id"] for c in get_model_config_CASES])
-def test_model_config(tmp_path, monkeypatch, basic_config, case):
-    global_dir = tmp_path / "home"
-    local_dir = tmp_path / "local"
-    global_dir.mkdir()
-    local_dir.mkdir()
+def test_model_config(mock_paths, monkeypatch, basic_config, case):
+    global_dir = mock_paths.home_dir
+    local_dir = mock_paths.cwd_dir
     monkeypatch.setattr(Path, "home", lambda: global_dir)
     monkeypatch.setattr(Path, "cwd", lambda: local_dir)
 

--- a/tests/test_run_template.py
+++ b/tests/test_run_template.py
@@ -799,11 +799,9 @@ get_run_template_cli_CASES = [
      "expected_regex_output": ["^$"]},
 ]
 @pytest.mark.parametrize("case", get_run_template_cli_CASES, ids=[c["id"] for c in get_run_template_cli_CASES])
-def test_run_template_cli(tmp_path, monkeypatch, case, template, basic_config):
-    global_dir = tmp_path / "home"
-    local_dir = tmp_path / "local"
-    global_dir.mkdir()
-    local_dir.mkdir()
+def test_run_template_cli(mock_paths, monkeypatch, case, template, basic_config):
+    global_dir = mock_paths.home_dir
+    local_dir = mock_paths.cwd_dir
 
     monkeypatch.setattr(Path, "home", lambda: global_dir)
     monkeypatch.setattr(Path, "cwd", lambda: local_dir)
@@ -841,7 +839,7 @@ def test_run_template_cli(tmp_path, monkeypatch, case, template, basic_config):
         template_global.save(FileScope.GLOBAL)
 
     runner = CliRunner()
-    with runner.isolated_filesystem(temp_dir=tmp_path):
+    with runner.isolated_filesystem(temp_dir=mock_paths.home_dir):
         result = runner.invoke(run_group, case.get("args"))
         if case.get("expected_output") is not None:
             if type(case.get("expected_output")) == str:

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -7,6 +7,7 @@ from prich.models.file_scope import FileScope
 from prich.cli.validate import validate_templates
 from tests.fixtures.templates import template
 from tests.fixtures.config import basic_config
+from tests.fixtures.paths import mock_paths
 
 get_validate_template_CASES = [
     {"id": "local_and_global_params", "args": ["-g", "-l"],
@@ -82,11 +83,9 @@ get_validate_template_CASES = [
      ]},
 ]
 @pytest.mark.parametrize("case", get_validate_template_CASES, ids=[c["id"] for c in get_validate_template_CASES])
-def test_validate_template(tmp_path, monkeypatch, case, template, basic_config):
-    global_dir = tmp_path / "home"
-    local_dir = tmp_path / "local"
-    global_dir.mkdir()
-    local_dir.mkdir()
+def test_validate_template(mock_paths, monkeypatch, case, template, basic_config):
+    global_dir = mock_paths.home_dir
+    local_dir = mock_paths.cwd_dir
 
     monkeypatch.setattr(Path, "home", lambda: global_dir)
     monkeypatch.setattr(Path, "cwd", lambda: local_dir)
@@ -125,7 +124,7 @@ def test_validate_template(tmp_path, monkeypatch, case, template, basic_config):
         template_local_wrong.save(FileScope.LOCAL)
 
     runner = CliRunner()
-    with runner.isolated_filesystem(temp_dir=tmp_path):
+    with runner.isolated_filesystem(temp_dir=mock_paths.home_dir):
         result = runner.invoke(validate_templates, case.get("args"))
         if case.get("expected_output") is not None:
             if type(case.get("expected_output")) == str:


### PR DESCRIPTION
### **1. Centralized Directory Access Functions**
- Replaced direct use of `Path.cwd()` and `Path.home()` with calls to `get_cwd_dir()` and `get_home_dir()`.
- Introduced `get_prich_dir(global_only=False)` to abstract access to the Prich directory (either local or global).

### **2. Test Changes **

1. **Replaced `tmp_path` with `mock_paths`**:
   - Previously, tests used `tmp_path` (a pytest fixture) to create temporary directories.
   - Now, they use a custom `mock_paths` fixture that simulates the file system (e.g., `home_dir`, `cwd_dir`), avoiding real file operations.

2. **Mocked `home_dir` and `cwd_dir`**:
   - The `mock_paths` fixture provides mock values for the user's home directory (`home_dir`) and the current working directory (`cwd_dir`).
   - These are used in tests to simulate environment paths without interacting with the real file system.

3. **Removed hardcoded paths**:
   - Directories like `/home/user`, `/tmp`, or `/var` are no longer hardcoded. Instead, they are dynamically provided by the `mock_paths` fixture.

4. **Added tests for click cli template run**
   - Check Quiet option
   - Check Verbose option
   - Check Only final output option
