### PR TITLE
validate template updated with detailed issues descriptions and doc links

### DIFF
--- a/prich/cli/validate.py
+++ b/prich/cli/validate.py
@@ -1,11 +1,93 @@
 import os
+import re
 from pathlib import Path
 import click
+import yaml
+from pydantic import ValidationError as PydanticValidationError
 from prich.constants import PRICH_DIR_NAME
 from prich.models.template import CommandStep, PythonStep
 from prich.core.file_scope import classify_path
-from prich.core.loaders import find_template_files, load_template_model, get_env_vars
+from prich.core.loaders import find_template_files, load_template_model, get_env_vars, _load_yaml
 from prich.core.utils import console_print, shorten_path, get_prich_dir, is_just_filename, get_cwd_dir, get_home_dir
+
+
+def template_model_doctor(template_yaml: dict, model_load_error: PydanticValidationError) -> list[str]:
+    """Doctor method to describe template model loading failures with detailed yaml key highlight"""
+    if template_yaml is None:
+        raise click.ClickException("Template YAML data is missing")
+    found_issues_list = []
+    for err in model_load_error.errors():
+        details = None
+        if template_yaml and err.get("loc"):
+            # hide extra layering
+            if err.get("loc")[0] == "steps":
+                if err.get("loc")[2] in ['llm', 'command', 'python', 'render']:
+                    details = err.get("loc")[2]
+                    err['loc'] = tuple(err.get("loc")[:2] + err.get("loc")[3:])
+
+            trace_dir = template_yaml.copy()
+            loc_list = err.get("loc")[:-1] if len(err.get("loc")) > 1 else err.get("loc")
+            for x in loc_list:
+                try:
+                    trace_dir = trace_dir[x]
+                except Exception:
+                    break
+            template_overview = yaml.safe_dump(trace_dir, explicit_start=True, explicit_end=True, indent=2,
+                                               sort_keys=False)
+            # highlight not permitted field
+            if 'Extra inputs are not permitted' in err.get("msg"):
+                template_overview = re.sub(f"([\n]*\\s|^)({err.get('loc')[-1]})(:)", "\\1[red]\\2[/red]\\3",
+                                           template_overview, count=1)
+            # highlight block with required field
+            elif 'Field required' in err.get("msg"):
+                template_overview = re.sub("(\.\.\.)", f"[yellow]+{err.get('loc')[-1]}: ...[/yellow]\n\\1",
+                                           template_overview, count=1)
+            else:
+                highligh_block = err.get('loc')[-1] if isinstance(err.get('loc')[-1], str) else err.get('loc')[-2]
+                template_overview = re.sub(f"([\n]*(?:\s+)|^)({highligh_block})(:)", "\\1[red]\\2[/red]\\3",
+                                           template_overview, count=1)
+            err_loc_list = []
+            for err_loc_item in err.get('loc'):
+                if isinstance(err_loc_item, int):
+                    err_loc_list.append(f"[[cyan]{str(err_loc_item + 1)}[/cyan]]")
+                else:
+                    err_loc_list.append(err_loc_item)
+            err_loc_string = '.'.join(err_loc_list).replace(".[", "[")
+            if err.get("loc")[0] == "steps":
+                doc_items = ["See Steps documentation:"]
+                if len(err.get("loc")) >= 3 and isinstance(err.get("loc")[2], str) and err.get("loc")[2].startswith(
+                        "extract_var"):
+                    doc_items.append(
+                        "Extract Variables: https://oleks-dev.github.io/prich/reference/template/steps/#extract-variables")
+                elif len(err.get("loc")) >= 3 and isinstance(err.get("loc")[2], str) and err.get("loc")[2].startswith(
+                        "validat"):
+                    doc_items.append(
+                        "Validate Output: https://oleks-dev.github.io/prich/reference/template/steps/#validate-output")
+                elif len(err.get("loc")) >= 3 and err.get("loc")[2] == "when":
+                    doc_items.append(
+                        "When to Execute: https://oleks-dev.github.io/prich/reference/template/steps/#when-to-execute-conditional-statement")
+                elif len(err.get("loc")) >= 3 and isinstance(err.get("loc")[2], str) and (
+                        err.get("loc")[2].startswith("filter") or err.get("loc")[2].startswith("split") or
+                        err.get("loc")[2].startswith("strip") or err.get("loc")[2].startswith("regex") or
+                        err.get("loc")[2].startswith("extract_regex")):
+                    doc_items.append(
+                        "Output Text Transformations: https://oleks-dev.github.io/prich/reference/template/steps/#output-text-transformations")
+                elif len(err.get("loc")) >= 3 and isinstance(err.get("loc")[2], str) and err.get("loc")[2].startswith(
+                        "output_"):
+                    doc_items.append(
+                        "Store And Show Output: https://oleks-dev.github.io/prich/reference/template/steps/#store-and-show-output")
+                if details and details in ["llm", "pyhon", "command", "render"]:
+                    doc_items.append(
+                        f"{details} step: https://oleks-dev.github.io/prich/reference/template/steps/#{details}-step")
+                doc_items.append("https://oleks-dev.github.io/prich/reference/template/steps/")
+                doc = '\n'.join(doc_items)
+            elif err.get("loc")[0] == "variables":
+                doc = "See Variables documentation https://oleks-dev.github.io/prich/reference/template/variables/"
+            else:
+                doc = "See Template Content Documentation https://oleks-dev.github.io/prich/reference/template/content/"
+            err_loc_string = re.sub(f"({err.get('loc')[-1]})$", f"[red]\\1[/red]", err_loc_string)
+            found_issues_list.append(f"""{len(found_issues_list)+1}. [red]{err.get('msg')}[/red] '{err_loc_string}':\n{template_overview}{doc}""")
+    return found_issues_list
 
 
 @click.command(name="validate")
@@ -53,14 +135,29 @@ def validate_templates(template_id: str, validate_file: Path, global_only: bool,
 
     failures_found = False
     for template_file in template_files:
+        template_yaml = None
+        template_id = None
+        template_name = None
+        failures_list = []
+        model_failures_count = 0
+        if template_file.is_file():
+            template_yaml = _load_yaml(template_file)
+            template_id = template_yaml.get("id") if template_yaml else None
+            template_name = template_yaml.get("name") if template_yaml else None
         try:
-            template = load_template_model(template_file)
-            console_print(f"- {template.id} [dim]({template.source.value}) {shorten_path(str(template_file))}[/dim]: [green]is valid[/green]")
+            try:
+                template = load_template_model(template_file)
+            except PydanticValidationError as e:
+                found_model_issues = template_model_doctor(template_yaml, e)
+                model_failures_count = len(found_model_issues)
+                found_model_issues_string = '\n\n'.join(found_model_issues)
+                raise click.ClickException(found_model_issues_string)
+            except Exception as e:
+                raise click.ClickException(f"1. [red]{str(e)}[/red]")
             if template.venv in ["isolated", "shared"]:
                 venv_folder = (Path(template.folder) / "scripts") if template.venv == "isolated" else get_prich_dir() / "venv"
                 if not venv_folder.exists():
-                    console_print(f"  [red]Failed to find {template.venv} venv at {shorten_path(str(venv_folder))}. Install it by running 'prich venv-install {template.id}'.[/red]")
-                    failures_found = True
+                    failures_list.append(f"{len(failures_list)+1}. [red]Failed to find {template.venv} venv at {shorten_path(str(venv_folder))}.[/red] Install it by running 'prich venv-install {template.id}'.")
             idx = 0
             for step in template.steps:
                 idx += 1
@@ -76,18 +173,26 @@ def validate_templates(template_id: str, validate_file: Path, global_only: bool,
                                         call_file = path / Path(step.call)
                                         break
                     if call_file.exists() and not os.access(call_file, os.X_OK) and type(step) == CommandStep:
-                        console_print(f"  [red]The call command {shorten_path(str(call_file))} file is not executable in step #{idx} {step.name}[/red]")
-                        failures_found = True
+                        failures_list.append(f"{len(failures_list)+1}. [red]The call command {shorten_path(str(call_file))} file is not executable in step[/red] [white]#{idx} {step.name}[/white]")
                     elif not call_file.exists() and not (Path(template.folder) / "scripts" / call_file).exists():
                         if is_just_filename(call_file):
                             full_path = str(Path(template.folder) / "scripts" / call_file)
                         else:
                             full_path = str(call_file)
-                        console_print(f"  [red]Failed to find call {step.type} file {shorten_path(full_path)} for step #{idx} {step.name}")
-
+                        failures_list.append(f"{len(failures_list)+1}. [red]Failed to find call {step.type} file {shorten_path(full_path)}[/red] for step #{idx} {step.name}")
+            console_print(f"- {template.id} [dim]({template.source.value}) {shorten_path(str(template_file))}[/dim]: ", end='')
+            if len(failures_list) > 0:
+                failures_found = True
+                console_print(f"[red]is not valid[/red] ({len(failures_list)} issues)")
+                failures = '  ' + f'\n  '.join(failures_list)
+                console_print(failures)
+                console_print()
+            else:
+                console_print("[green]is valid[/green]")
         except click.ClickException as e:
             failures_found = True
             template_source = classify_path(template_file)
-            console_print(f"- [dim]({template_source.value}) {shorten_path(str(template_file))}[/dim]: [red]is not valid[/red]\n  [red]{e.message.replace(f' from {template_file}', '')}[/red]")
+            error_lines = '  ' + '\n  '.join([x for x in e.message.split('\n')]) + '\n'
+            console_print(f"""- {f"{template_id} " if template_id else ''}[dim]({template_source.value}) {shorten_path(str(template_file))}[/dim]: [red]is not valid[/red] {f'({model_failures_count} issues)' if model_failures_count > 0 else '(1 issue)'}\n  [red]Failed to load template{f" {template_id}" if template_id else ""}{f" ({template_name})" if template_name else ""}[/red]:\n{error_lines}""")
     if failures_found:
         sys.exit(1)

--- a/prich/models/template.py
+++ b/prich/models/template.py
@@ -40,6 +40,8 @@ class ValidateStepOutput(BaseModel):
 
 
 class ExtractVarModel(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
     regex: str
     variable: str
     multiple: Optional[bool] = False  # default: single match
@@ -61,6 +63,8 @@ class ExtractVarModel(BaseModel):
 
 
 class OutputFileModel(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
     name: Optional[str | None] = None
     mode: Optional[Literal["write", "append"] | None] = None
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -50,10 +50,10 @@ get_validate_template_CASES = [
          }
      ],
      "expected_output": [
-         "template-global.yaml: is valid",
+         "template-global.yaml: is not valid",
          "Failed to find call command file ~/.prich/templates/template-global/scripts/echo1",
          "Failed to find call command file ~/.prich/templates/template-global/scripts/echo2",
-         "template-local.yaml: is valid",
+         "template-local.yaml: is not valid",
          "Failed to find call command file ./.prich/templates/template-local/scripts/echo1",
          "Failed to find call command file ./.prich/templates/template-local/scripts/echo2",
      ]},
@@ -72,11 +72,11 @@ get_validate_template_CASES = [
          }
      ],
      "expected_output": [
-         "template-global.yaml: is valid",
+         "template-global.yaml: is not valid",
          "Failed to find isolated venv at ~/.prich/templates/template-global/scripts",
          "Failed to find call python file ~/.prich/templates/template-global/scripts/echo1.py",
          "Failed to find call python file ~/.prich/templates/template-global/scripts/echo2.py",
-         "template-local.yaml: is valid",
+         "template-local.yaml: is not valid",
          "Failed to find isolated venv at ./.prich/templates/template-local/scripts",
          "Failed to find call python file ./.prich/templates/template-local/scripts/echo1.py",
          "Failed to find call python file ./.prich/templates/template-local/scripts/echo2.py",


### PR DESCRIPTION
**Enhanced Validation (doctor-style) for Template Validation command**  

**Detailed Template Validation Errors**  
- **New `template_model_doctor` function** provides structured, color-coded error messages when loading template models.  
  - Used in `prich validate` command
  - Highlights invalid YAML keys with red formatting and links to relevant documentation.  
  - Example:  
```command line
- test-tpl (local) ~/projects/prich/.prich/templates/test-tpl/test-tpl.yaml: is not valid (2 issues)
  Failed to load template test-tpl (Test Tpl):
  1. Extra inputs are not permitted 'steps[1].<strip_output>':
  ---
  <strip_output>: true
  name: Ask to generate text
  type: llm
  instructions: You are {{ role }}
  input: Generate text about {{ topic }}
  ...
  See Steps documentation:
  Output Text Transformations: https://oleks-dev.github.io/prich/reference/template/steps/#output-text-transformations
  llm step: https://oleks-dev.github.io/prich/reference/template/steps/#llm-step
  https://oleks-dev.github.io/prich/reference/template/steps/
```  