### PR TITLE
unify model field in provider config

### DIFF
--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -98,7 +98,7 @@ openai-gpt4o:
 ```yaml
 mlx-mistral-7b:
   provider_type: "mlx_local"
-  model_path: "/path/to/model"
+  model: "/path/to/model"
   mode: flat
   max_tokens: 3000
 ```

--- a/prich/cli/config.py
+++ b/prich/cli/config.py
@@ -23,15 +23,11 @@ def list_providers(global_only: bool, local_only: bool, details: bool):
     console_print(f"[bold]Configs[/bold]: {', '.join(_readable_paths(paths))}")
     console_print(f"[bold]Providers{' ([green]global[/green])' if global_only else ' ([green]local[/green])' if local_only else ''}[/bold]:")
     for provider, provider_config in config.providers.items():
-        provider_model = ""
-        if provider_config.provider_type == 'mlx_local':
-            if 'model_path' in provider_config.model_dump().keys():
-                provider_model = provider_config.model_path
-        else:
-            if 'model' in provider_config.model_dump().keys():
-                provider_model = provider_config.model
-            elif provider_config.model_dump().get("options") and 'model' in provider_config.model_dump()["options"].keys():
-                provider_model = provider_config.options.get("model")
+        provider_model = None
+        if 'model' in provider_config.model_dump().keys():
+            provider_model = provider_config.model
+        elif provider_config.model_dump().get("options") and 'model' in provider_config.model_dump()["options"].keys():
+            provider_model = provider_config.options.get("model")
         console_print(f"- [green]{provider}[/green] [dim]([green]{provider_config.provider_type}[/green]{f', [green]{provider_model}[/green]' if provider_model else ''})[/dim]")
         if details:
             for k, v in provider_config.model_dump().items():

--- a/prich/llm_providers/mlx_local_provider.py
+++ b/prich/llm_providers/mlx_local_provider.py
@@ -38,11 +38,11 @@ class MLXLocalProvider(LLMProvider, LazyOptionalProvider):
         self.stream_generate = self._lazy_import_from("mlx_lm.generate", "stream_generate", pip_name="mlx")
 
         try:
-            model_identifier = Path(os.path.expanduser(self.provider.model_path))
+            model_identifier = Path(os.path.expanduser(self.provider.model))
             self.model, _ = self.load(str(model_identifier))
             self.tokenizer = self.load_tokenizer(model_identifier)
         except Exception as e:
-            raise click.ClickException(f"mlx_local provider failed to load model {self.provider.model_path}: {str(e)}")
+            raise click.ClickException(f"mlx_local provider failed to load model {self.provider.model}: {str(e)}")
 
         self.client = True
 

--- a/prich/models/config_providers.py
+++ b/prich/models/config_providers.py
@@ -34,7 +34,7 @@ class OpenAIProviderModel(BaseProviderModel):
 
 class MLXLocalProviderModel(BaseProviderModel):
     provider_type: Literal["mlx_local"]
-    model_path: str
+    model: str
 
     # generate
     #


### PR DESCRIPTION
Change `model_path` to just `model` for mlx local provider to make unified model field for simplicity